### PR TITLE
Issue-39:  Encapsulate logic for viewmodel's on main screen

### DIFF
--- a/app/src/main/java/com/kirchhoff/movies/data/Data.kt
+++ b/app/src/main/java/com/kirchhoff/movies/data/Data.kt
@@ -1,0 +1,20 @@
+package com.kirchhoff.movies.data
+
+data class Movie(
+    val id: Int,
+    val title: String,
+    val poster_path: String?,
+    val backdrop_path: String?
+)
+
+data class Person(
+    val id: Int,
+    val name: String,
+    val profile_path: String?
+)
+
+data class Tv(
+    val id: Int,
+    val poster_path: String?,
+    val name: String
+)

--- a/app/src/main/java/com/kirchhoff/movies/data/DiscoverMoviesResponse.kt
+++ b/app/src/main/java/com/kirchhoff/movies/data/DiscoverMoviesResponse.kt
@@ -1,8 +1,0 @@
-package com.kirchhoff.movies.data
-
-data class DiscoverMoviesResponse(
-    val page: Int,
-    val results: List<Movie>,
-    val total_results: Int,
-    val total_pages: Int
-)

--- a/app/src/main/java/com/kirchhoff/movies/data/DiscoverTvsResponse.kt
+++ b/app/src/main/java/com/kirchhoff/movies/data/DiscoverTvsResponse.kt
@@ -1,8 +1,0 @@
-package com.kirchhoff.movies.data
-
-data class DiscoverTvsResponse(
-    val page: Int,
-    val results: List<Tv>,
-    val total_results: Int,
-    val total_pages: Int
-)

--- a/app/src/main/java/com/kirchhoff/movies/data/Movie.kt
+++ b/app/src/main/java/com/kirchhoff/movies/data/Movie.kt
@@ -1,8 +1,0 @@
-package com.kirchhoff.movies.data
-
-data class Movie(
-    val id: Int,
-    val title: String,
-    val poster_path: String?,
-    val backdrop_path: String?
-)

--- a/app/src/main/java/com/kirchhoff/movies/data/Person.kt
+++ b/app/src/main/java/com/kirchhoff/movies/data/Person.kt
@@ -1,7 +1,0 @@
-package com.kirchhoff.movies.data
-
-data class Person(
-    val id: Int,
-    val name: String,
-    val profile_path: String?
-)

--- a/app/src/main/java/com/kirchhoff/movies/data/PersonsResponse.kt
+++ b/app/src/main/java/com/kirchhoff/movies/data/PersonsResponse.kt
@@ -1,8 +1,0 @@
-package com.kirchhoff.movies.data
-
-data class PersonsResponse(
-    val page: Int,
-    val results: List<Person>,
-    val total_results: Int,
-    val total_pages: Int
-)

--- a/app/src/main/java/com/kirchhoff/movies/data/Tv.kt
+++ b/app/src/main/java/com/kirchhoff/movies/data/Tv.kt
@@ -1,7 +1,0 @@
-package com.kirchhoff.movies.data
-
-data class Tv(
-    val id: Int,
-    val poster_path: String?,
-    val name: String
-)

--- a/app/src/main/java/com/kirchhoff/movies/data/responses/MainScreenResponses.kt
+++ b/app/src/main/java/com/kirchhoff/movies/data/responses/MainScreenResponses.kt
@@ -1,0 +1,26 @@
+package com.kirchhoff.movies.data.responses
+
+import com.kirchhoff.movies.data.Movie
+import com.kirchhoff.movies.data.Person
+import com.kirchhoff.movies.data.Tv
+
+data class DiscoverMoviesResponse(
+    val page: Int,
+    val results: List<Movie>,
+    val total_results: Int,
+    val total_pages: Int
+)
+
+data class DiscoverTvsResponse(
+    val page: Int,
+    val results: List<Tv>,
+    val total_results: Int,
+    val total_pages: Int
+)
+
+data class PersonsResponse(
+    val page: Int,
+    val results: List<Person>,
+    val total_results: Int,
+    val total_pages: Int
+)

--- a/app/src/main/java/com/kirchhoff/movies/network/services/DiscoverService.kt
+++ b/app/src/main/java/com/kirchhoff/movies/network/services/DiscoverService.kt
@@ -1,7 +1,7 @@
 package com.kirchhoff.movies.network.services
 
-import com.kirchhoff.movies.data.DiscoverMoviesResponse
-import com.kirchhoff.movies.data.DiscoverTvsResponse
+import com.kirchhoff.movies.data.responses.DiscoverMoviesResponse
+import com.kirchhoff.movies.data.responses.DiscoverTvsResponse
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query

--- a/app/src/main/java/com/kirchhoff/movies/network/services/PersonService.kt
+++ b/app/src/main/java/com/kirchhoff/movies/network/services/PersonService.kt
@@ -1,6 +1,6 @@
 package com.kirchhoff.movies.network.services
 
-import com.kirchhoff.movies.data.PersonsResponse
+import com.kirchhoff.movies.data.responses.PersonsResponse
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query

--- a/app/src/main/java/com/kirchhoff/movies/repository/discover/DiscoverRepository.kt
+++ b/app/src/main/java/com/kirchhoff/movies/repository/discover/DiscoverRepository.kt
@@ -1,7 +1,7 @@
 package com.kirchhoff.movies.repository.discover
 
-import com.kirchhoff.movies.data.DiscoverMoviesResponse
-import com.kirchhoff.movies.data.DiscoverTvsResponse
+import com.kirchhoff.movies.data.responses.DiscoverMoviesResponse
+import com.kirchhoff.movies.data.responses.DiscoverTvsResponse
 import com.kirchhoff.movies.network.services.DiscoverService
 import com.kirchhoff.movies.repository.BaseRepository
 import com.kirchhoff.movies.repository.Result

--- a/app/src/main/java/com/kirchhoff/movies/repository/discover/IDiscoverRepository.kt
+++ b/app/src/main/java/com/kirchhoff/movies/repository/discover/IDiscoverRepository.kt
@@ -1,7 +1,7 @@
 package com.kirchhoff.movies.repository.discover
 
-import com.kirchhoff.movies.data.DiscoverMoviesResponse
-import com.kirchhoff.movies.data.DiscoverTvsResponse
+import com.kirchhoff.movies.data.responses.DiscoverMoviesResponse
+import com.kirchhoff.movies.data.responses.DiscoverTvsResponse
 import com.kirchhoff.movies.repository.Result
 
 interface IDiscoverRepository {

--- a/app/src/main/java/com/kirchhoff/movies/repository/person/IPersonsRepository.kt
+++ b/app/src/main/java/com/kirchhoff/movies/repository/person/IPersonsRepository.kt
@@ -1,6 +1,6 @@
 package com.kirchhoff.movies.repository.person
 
-import com.kirchhoff.movies.data.PersonsResponse
+import com.kirchhoff.movies.data.responses.PersonsResponse
 import com.kirchhoff.movies.repository.Result
 
 interface IPersonsRepository {

--- a/app/src/main/java/com/kirchhoff/movies/repository/person/PersonsRepository.kt
+++ b/app/src/main/java/com/kirchhoff/movies/repository/person/PersonsRepository.kt
@@ -1,6 +1,6 @@
 package com.kirchhoff.movies.repository.person
 
-import com.kirchhoff.movies.data.PersonsResponse
+import com.kirchhoff.movies.data.responses.PersonsResponse
 import com.kirchhoff.movies.network.services.PersonService
 import com.kirchhoff.movies.repository.BaseRepository
 import com.kirchhoff.movies.repository.Result

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/MainScreenVM.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/MainScreenVM.kt
@@ -1,0 +1,48 @@
+package com.kirchhoff.movies.ui.screens.main
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kirchhoff.movies.repository.Result
+import kotlinx.coroutines.launch
+
+abstract class MainScreenVM<T> : ViewModel() {
+
+    protected abstract suspend fun loadData(page: Int): Result<T>
+
+    private val _loading = MutableLiveData<Boolean>()
+    val loading: LiveData<Boolean> = _loading
+
+    private val _paginating = MutableLiveData<Boolean>()
+    val paginating: LiveData<Boolean> = _paginating
+
+    private val _error = MutableLiveData<String>()
+    val error: LiveData<String> = _error
+
+    private val _data = MutableLiveData<T>()
+    val data: LiveData<T> = _data
+
+    fun fetchData(page: Int) {
+        if (page == 1) {
+            _loading.postValue(true)
+        } else {
+            _paginating.postValue(true)
+        }
+
+        viewModelScope.launch {
+            val result = loadData(page)
+
+            if (page == 1) {
+                _loading.postValue(false)
+            } else {
+                _paginating.postValue(false)
+            }
+
+            when (result) {
+                is Result.Success -> _data.postValue(result.data)
+                else -> _error.postValue(result.toString())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/movies/MoviesFragment.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/movies/MoviesFragment.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.GridLayoutManager
 import com.kirchhoff.movies.R
-import com.kirchhoff.movies.data.DiscoverMoviesResponse
+import com.kirchhoff.movies.data.responses.DiscoverMoviesResponse
 import com.kirchhoff.movies.databinding.FragmentMoviesBinding
 import com.kirchhoff.movies.extensions.getSizeFromRes
 import com.kirchhoff.movies.ui.screens.BaseFragment
@@ -49,13 +49,13 @@ class MoviesFragment : BaseFragment(R.layout.fragment_movies) {
         with(vm) {
             loading.subscribe { viewBinding.pbMovies.isVisible = it }
             paginating.subscribe { viewBinding.pbPaginate.isVisible = it }
-            moviesResponse.subscribe(::obtainMoviesResponse)
+            data.subscribe(::obtainMoviesResponse)
             error.subscribe { Toast.makeText(requireContext(), it, Toast.LENGTH_LONG).show() }
         }
     }
 
     private fun loadMovies(page: Int) {
-        vm.discoverMovies(page)
+        vm.fetchData(page)
         paginator.isLoading = true
     }
 

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/movies/MoviesVM.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/movies/MoviesVM.kt
@@ -1,48 +1,10 @@
 package com.kirchhoff.movies.ui.screens.main.movies
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.kirchhoff.movies.data.DiscoverMoviesResponse
-import com.kirchhoff.movies.repository.Result
+import com.kirchhoff.movies.data.responses.DiscoverMoviesResponse
 import com.kirchhoff.movies.repository.discover.IDiscoverRepository
-import kotlinx.coroutines.launch
+import com.kirchhoff.movies.ui.screens.main.MainScreenVM
 
-class MoviesVM(private val discoverRepository: IDiscoverRepository) : ViewModel() {
-
-    private val _loading = MutableLiveData<Boolean>()
-    val loading: LiveData<Boolean> = _loading
-
-    private val _paginating = MutableLiveData<Boolean>()
-    val paginating: LiveData<Boolean> = _paginating
-
-    private val _error = MutableLiveData<String>()
-    val error: LiveData<String> = _error
-
-    private val _moviesResponse = MutableLiveData<DiscoverMoviesResponse>()
-    val moviesResponse: LiveData<DiscoverMoviesResponse> = _moviesResponse
-
-    fun discoverMovies(page: Int) {
-        if (page == 1) {
-            _loading.postValue(true)
-        } else {
-            _paginating.postValue(true)
-        }
-
-        viewModelScope.launch {
-            val result = discoverRepository.fetchMovies(page)
-
-            if (page == 1) {
-                _loading.postValue(false)
-            } else {
-                _paginating.postValue(false)
-            }
-
-            when (result) {
-                is Result.Success -> _moviesResponse.postValue(result.data)
-                else -> _error.postValue(result.toString())
-            }
-        }
-    }
+class MoviesVM(private val discoverRepository: IDiscoverRepository) :
+    MainScreenVM<DiscoverMoviesResponse>() {
+    override suspend fun loadData(page: Int) = discoverRepository.fetchMovies(page)
 }

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/persons/PersonsFragment.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/persons/PersonsFragment.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.GridLayoutManager
 import com.kirchhoff.movies.R
-import com.kirchhoff.movies.data.PersonsResponse
+import com.kirchhoff.movies.data.responses.PersonsResponse
 import com.kirchhoff.movies.databinding.FragmentPersonsBinding
 import com.kirchhoff.movies.extensions.getSizeFromRes
 import com.kirchhoff.movies.ui.screens.BaseFragment
@@ -49,13 +49,13 @@ class PersonsFragment : BaseFragment(R.layout.fragment_persons) {
         with(vm) {
             loading.subscribe { viewBinding.pbPersons.isVisible = it }
             paginating.subscribe { viewBinding.pbPaginate.isVisible = it }
-            personsResponse.subscribe(::obtainPersonsResponse)
+            data.subscribe(::obtainPersonsResponse)
             error.subscribe { Toast.makeText(requireContext(), it, Toast.LENGTH_LONG).show() }
         }
     }
 
     private fun loadPersons(page: Int) {
-        vm.loadPersons(page)
+        vm.fetchData(page)
         paginator.isLoading = true
     }
 

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/persons/PersonsVM.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/persons/PersonsVM.kt
@@ -1,48 +1,10 @@
 package com.kirchhoff.movies.ui.screens.main.persons
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.kirchhoff.movies.data.PersonsResponse
-import com.kirchhoff.movies.repository.Result
+import com.kirchhoff.movies.data.responses.PersonsResponse
 import com.kirchhoff.movies.repository.person.IPersonsRepository
-import kotlinx.coroutines.launch
+import com.kirchhoff.movies.ui.screens.main.MainScreenVM
 
-class PersonsVM(private val personRepository: IPersonsRepository) : ViewModel() {
-
-    private val _loading = MutableLiveData<Boolean>()
-    val loading: LiveData<Boolean> = _loading
-
-    private val _paginating = MutableLiveData<Boolean>()
-    val paginating: LiveData<Boolean> = _paginating
-
-    private val _error = MutableLiveData<String>()
-    val error: LiveData<String> = _error
-
-    private val _personsResponse = MutableLiveData<PersonsResponse>()
-    val personsResponse: LiveData<PersonsResponse> = _personsResponse
-
-    fun loadPersons(page: Int) {
-        if (page == 1) {
-            _loading.postValue(true)
-        } else {
-            _paginating.postValue(true)
-        }
-
-        viewModelScope.launch {
-            val result = personRepository.fetchPopularPersons(page)
-
-            if (page == 1) {
-                _loading.postValue(false)
-            } else {
-                _paginating.postValue(false)
-            }
-
-            when (result) {
-                is Result.Success -> _personsResponse.postValue(result.data)
-                else -> _error.postValue(result.toString())
-            }
-        }
-    }
+class PersonsVM(private val personRepository: IPersonsRepository) :
+    MainScreenVM<PersonsResponse>() {
+    override suspend fun loadData(page: Int) = personRepository.fetchPopularPersons(page)
 }

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/tvs/TvsFragment.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/tvs/TvsFragment.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.kirchhoff.movies.R
-import com.kirchhoff.movies.data.DiscoverTvsResponse
+import com.kirchhoff.movies.data.responses.DiscoverTvsResponse
 import com.kirchhoff.movies.databinding.FragmentTvsBinding
 import com.kirchhoff.movies.ui.screens.BaseFragment
 import com.kirchhoff.movies.ui.screens.main.tvs.adapter.TvsListAdapter
@@ -46,13 +46,13 @@ class TvsFragment : BaseFragment(R.layout.fragment_tvs) {
         with(vm) {
             loading.subscribe { viewBinding.pbTvs.isVisible = it }
             paginating.subscribe { viewBinding.pbPaginate.isVisible = it }
-            tvsResponse.subscribe(::obtainTvsResponse)
+            data.subscribe(::obtainTvsResponse)
             error.subscribe { Toast.makeText(requireContext(), it, Toast.LENGTH_LONG).show() }
         }
     }
 
     private fun loadTvs(page: Int) {
-        vm.discoverTvs(page)
+        vm.fetchData(page)
         paginator.isLoading = true
     }
 

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/tvs/TvsVM.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/tvs/TvsVM.kt
@@ -1,48 +1,10 @@
 package com.kirchhoff.movies.ui.screens.main.tvs
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.kirchhoff.movies.data.DiscoverTvsResponse
-import com.kirchhoff.movies.repository.Result
+import com.kirchhoff.movies.data.responses.DiscoverTvsResponse
 import com.kirchhoff.movies.repository.discover.IDiscoverRepository
-import kotlinx.coroutines.launch
+import com.kirchhoff.movies.ui.screens.main.MainScreenVM
 
-class TvsVM(private val discoverRepository: IDiscoverRepository) : ViewModel() {
-
-    private val _loading = MutableLiveData<Boolean>()
-    val loading: LiveData<Boolean> = _loading
-
-    private val _paginating = MutableLiveData<Boolean>()
-    val paginating: LiveData<Boolean> = _paginating
-
-    private val _error = MutableLiveData<String>()
-    val error: LiveData<String> = _error
-
-    private val _tvsResponse = MutableLiveData<DiscoverTvsResponse>()
-    val tvsResponse: LiveData<DiscoverTvsResponse> = _tvsResponse
-
-    fun discoverTvs(page: Int) {
-        if (page == 1) {
-            _loading.postValue(true)
-        } else {
-            _paginating.postValue(true)
-        }
-
-        viewModelScope.launch {
-            val result = discoverRepository.fetchTvs(page)
-
-            if (page == 1) {
-                _loading.postValue(false)
-            } else {
-                _paginating.postValue(false)
-            }
-
-            when (result) {
-                is Result.Success -> _tvsResponse.postValue(result.data)
-                else -> _error.postValue(result.toString())
-            }
-        }
-    }
+class TvsVM(private val discoverRepository: IDiscoverRepository) :
+    MainScreenVM<DiscoverTvsResponse>() {
+    override suspend fun loadData(page: Int) = discoverRepository.fetchTvs(page)
 }


### PR DESCRIPTION
#39 
Created MainScreenVM.kt and use it as parent for TvsVM, PersonsVM, MoviesVM. Refactored data classes in data package.
