### PR TITLE
Issue-349: Fixed memory leaks in list adapter

### DIFF
--- a/core/src/main/java/com/kirchhoff/movies/core/ui/paginated/PaginatedScreenFragment.kt
+++ b/core/src/main/java/com/kirchhoff/movies/core/ui/paginated/PaginatedScreenFragment.kt
@@ -1,7 +1,9 @@
 package com.kirchhoff.movies.core.ui.paginated
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
@@ -13,21 +15,31 @@ import com.kirchhoff.movies.core.ui.recyclerview.Paginator
 import com.kirchhoff.movies.core.ui.recyclerview.adapter.BaseRecyclerViewAdapter
 import com.kirchhoff.movies.core.ui.recyclerview.adapter.viewholder.BaseVH
 import com.kirchhoff.movies.core.ui.recyclerview.decorations.GridMarginItemDecoration
-import com.kirchhoff.movies.core.ui.utils.viewBinding
 
-abstract class PaginatedScreenFragment<Data, T : UIPaginated<Data>> : BaseFragment(R.layout.fragment_paginated) {
+abstract class PaginatedScreenFragment<Data, T : UIPaginated<Data>> : BaseFragment() {
 
     abstract val configuration: Configuration
     abstract val listAdapter: BaseRecyclerViewAdapter<BaseVH<Data>, Data>
     abstract val vm: PaginatedScreenVM<T>
 
-    private val viewBinding by viewBinding(FragmentPaginatedBinding::bind)
+    private var _viewBinding: FragmentPaginatedBinding? = null
+    private val viewBinding get() = _viewBinding!!
+
     private lateinit var paginator: Paginator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         paginator = Paginator(loadMore = { loadData(it) }, threshold = configuration.threshold)
         loadData(1)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _viewBinding = FragmentPaginatedBinding.inflate(inflater, container, false)
+        return viewBinding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -62,6 +74,12 @@ abstract class PaginatedScreenFragment<Data, T : UIPaginated<Data>> : BaseFragme
             error.subscribe { Toast.makeText(requireContext(), it, Toast.LENGTH_LONG).show() }
             showEmptyResult.subscribe(::obtainViewsVisibility)
         }
+    }
+
+    override fun onDestroyView() {
+        viewBinding.rv.adapter = null
+        super.onDestroyView()
+        _viewBinding = null
     }
 
     protected fun displayTitle(title: String) {


### PR DESCRIPTION
A little bit tricky task. 

The reasons of this leaks and how them could be fixed can be found here - [Leak canary, Recyclerview leaking mAdapter](https://stackoverflow.com/questions/35520946/leak-canary-recyclerview-leaking-madapter)

But there was no possibility to apply such solution for our case, due to [`FragmentViewBindingDelegate`](https://github.com/Kirchhoff-/Movies/blob/master/core/src/main/java/com/kirchhoff/movies/core/ui/utils/FragmentViewBindingDelegate.kt), and this lines: https://github.com/Kirchhoff-/Movies/blob/c24c00006a8e94f8bd776e4909abd8b2fef0ab84/core/src/main/java/com/kirchhoff/movies/core/ui/utils/FragmentViewBindingDelegate.kt#L50-L52

if we are removing this lines, some strange behavior is happen - [link](https://drive.google.com/file/d/1eN-E0cN54nI6j1PdCsJryjUJfd0lmRk9/view?usp=sharing)

For sure, this could be fixed, but there is no such behavior with "standard" android mechanism for view binding. Once again, it is confirmed that the use of third-party code leads risks that are difficult to estimate initially. It is necessary to gradually abandon the use of this class (Replace it with  "standard" android mechanism for view binding or with jetpack compose). 

But even with correct view binding, there is a problem with blinking images after returning to dashboard screen - [link](https://drive.google.com/file/d/1UBsnqlGkkbn680nvOgro7j8_uYnc_lLZ/view?usp=sharing)

And it seems, that this is problem with Glide. This is one more reason to replace Glide with Coil. The whole list of reasons and general progress of the task could be found here - [Replace `Glide` with `Coil`](https://github.com/Kirchhoff-/Movies/issues/399). This task should be done in current release candidate, in order not to break user experience. 

Closes #349 