### PR TITLE
Issue-416: Kotlin and compose compiler libraries updated

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,14 +12,14 @@ constraintLayout = "2.1.4"
 flexbox = "3.0.0"
 coreKtx = "1.9.0"
 
-composeCompiler = "1.4.3"
+composeCompiler = "1.4.7"
 compose = "1.3.0"
 composeFoundation = "1.4.3"
 appCompat = "1.6.1"
 activityCompose = "1.3.1"
 composeLiveData = '1.4.3'
 
-kotlin = "1.8.10"
+kotlin = "1.8.21"
 coroutines = "1.6.4"
 
 lifecycle = "2.2.0"


### PR DESCRIPTION
Closes #416 

Also, updating Kotlin required updating the compose compiler library, due to this error:
<img width="1301" alt="Снимок экрана 2023-05-25 в 10 51 30" src="https://github.com/Kirchhoff-/Movies/assets/10849960/1bb9b7b5-3af7-4dd9-a125-605d22554fc9">
