### PR TITLE
Issue-558: Made `title` property in `UIMovie` class not nullable

### DIFF
--- a/core/src/main/java/com/kirchhoff/movies/core/data/UIMovie.kt
+++ b/core/src/main/java/com/kirchhoff/movies/core/data/UIMovie.kt
@@ -6,7 +6,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class UIMovie(
     val id: Int,
-    val title: String?,
+    val title: String,
     val posterPath: String?,
     val backdropPath: String?,
     val voteAverage: Float?

--- a/networkdata/src/main/java/com/kirchhoff/movies/networkdata/details/person/NetworkPersonDetailsData.kt
+++ b/networkdata/src/main/java/com/kirchhoff/movies/networkdata/details/person/NetworkPersonDetailsData.kt
@@ -17,6 +17,7 @@ data class NetworkPersonCredits(
 data class NetworkPersonCastCredit(
     @SerializedName("id") val id: Int,
     @SerializedName("title") val title: String?,
+    @SerializedName("name") val name: String?,
     @SerializedName("character") val character: String?,
     @SerializedName("poster_path") val posterPath: String?,
     @SerializedName("backdrop_patch") val backdropPath: String?,
@@ -26,6 +27,7 @@ data class NetworkPersonCastCredit(
 data class NetworkPersonCrewCredit(
     @SerializedName("id") val id: Int,
     @SerializedName("title") val title: String?,
+    @SerializedName("name") val name: String?,
     @SerializedName("job") val job: String,
     @SerializedName("poster_path") val posterPath: String?,
     @SerializedName("backdrop_path") val backdropPath: String?,

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsFragment.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsFragment.kt
@@ -66,7 +66,7 @@ internal class MovieDetailsFragment : BaseFragment(R.layout.fragment_movie_detai
         with(viewBinding) {
             ivBackdrop.downloadPoster(movie.backdropPath)
             toolbar.setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }
-            appbar.addTitleWithCollapsingListener(toolbar, movie.title.orEmpty())
+            appbar.addTitleWithCollapsingListener(toolbar, movie.title)
         }
 
         with(viewBinding.content.rvTrailers) {

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/viewmodel/MovieImagesViewModel.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/viewmodel/MovieImagesViewModel.kt
@@ -19,7 +19,7 @@ internal class MovieImagesViewModel(
 
     init {
         screenState.value = MovieImagesScreenState(
-            title = movie.title.orEmpty(),
+            title = movie.title,
             image = emptyList()
         )
     }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/ui/MovieListItemUI.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/ui/MovieListItemUI.kt
@@ -74,7 +74,7 @@ internal fun MovieListItemUI(
         Text(
             modifier = Modifier.height(50.dp),
             textAlign = TextAlign.Center,
-            text = movie.title.orEmpty(),
+            text = movie.title,
             color = colorResource(com.kirchhoff.movies.core.R.color.text_main),
             fontSize = 16.sp,
             maxLines = 2,

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/viewmodel/MovieListViewModel.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/viewmodel/MovieListViewModel.kt
@@ -38,7 +38,7 @@ internal class MovieListViewModel(
         val title = when (type) {
             is MovieListType.Genre -> StringValue.IdText(R.string.movie_movies_with_genre_format, type.genre.name)
             is MovieListType.Country -> StringValue.IdText(R.string.movie_movies_from_country_format, type.countryName)
-            is MovieListType.Similar -> StringValue.IdText(R.string.movie_similar_to_format, type.movie.title.orEmpty())
+            is MovieListType.Similar -> StringValue.IdText(R.string.movie_similar_to_format, type.movie.title)
         }
 
         screenState.value = screenState.value?.copy(title = title)

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/data/PersonDetailsData.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/data/PersonDetailsData.kt
@@ -17,14 +17,14 @@ internal data class UIPersonCredits(
 
 internal sealed class UIPersonCredit(
     val id: Int,
-    val title: String?,
+    val title: String,
     val posterPath: String?,
     val backdropPath: String?,
     val mediaType: UIMediaType
 ) {
     class Actor(
         id: Int,
-        title: String?,
+        title: String,
         posterPath: String?,
         backdropPath: String?,
         mediaType: UIMediaType,
@@ -33,7 +33,7 @@ internal sealed class UIPersonCredit(
 
     class Creator(
         id: Int,
-        title: String?,
+        title: String,
         posterPath: String?,
         backdropPath: String?,
         mediaType: UIMediaType,

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/mapper/details/PersonDetailsMapper.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/mapper/details/PersonDetailsMapper.kt
@@ -56,7 +56,7 @@ internal class PersonDetailsMapper : BaseMapper(),
     private fun createUIPersonActor(castCredit: NetworkPersonCastCredit) =
         UIPersonCredit.Actor(
             castCredit.id,
-            castCredit.title,
+            castCredit.title ?: castCredit.name ?: error("Wrong network data"),
             castCredit.posterPath,
             castCredit.backdropPath,
             createMediaType(castCredit.mediaType),
@@ -66,7 +66,7 @@ internal class PersonDetailsMapper : BaseMapper(),
     private fun createUIPersonCreator(crewCredit: NetworkPersonCrewCredit) =
         UIPersonCredit.Creator(
             crewCredit.id,
-            crewCredit.title,
+            crewCredit.title ?: crewCredit.name ?: error("Wrong network data"),
             crewCredit.posterPath,
             crewCredit.backdropPath,
             createMediaType(crewCredit.mediaType),


### PR DESCRIPTION
In this request - https://developer.themoviedb.org/reference/person-combined-credits , credits for tv-show returns without `title` property but with the `name`. Added correct handling of such situation. 

Closes #558 