### PR TITLE
Issue-636: `TextWithIcon` composable created

### DIFF
--- a/core/src/main/java/com/kirchhoff/movies/core/ui/compose/TextWithIcon.kt
+++ b/core/src/main/java/com/kirchhoff/movies/core/ui/compose/TextWithIcon.kt
@@ -1,0 +1,70 @@
+@file:SuppressWarnings("MagicNumber")
+
+package com.kirchhoff.movies.core.ui.compose
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun TextWithIcon(
+    imageVector: ImageVector,
+    text: String,
+    space: Dp = 4.dp,
+    style: TextStyle = textStyle
+) {
+    TextWithIcon(
+        painter = rememberVectorPainter(imageVector),
+        text = text,
+        space = space,
+        style = style
+    )
+}
+
+@Composable
+fun TextWithIcon(
+    painter: Painter,
+    text: String,
+    space: Dp = 4.dp,
+    style: TextStyle = textStyle
+) {
+    Icon(
+        painter = painter,
+        contentDescription = ""
+    )
+    Spacer(modifier = Modifier.width(space))
+    Text(
+        style = style,
+        text = text
+    )
+}
+
+private val textStyle: TextStyle = TextStyle(
+    fontSize = 14.sp,
+    color = Color.Black
+)
+
+@Preview
+@Composable
+private fun TextWithIconPreview() {
+    TextWithIcon(
+        imageVector = Icons.Filled.ArrowBack,
+        text = "Some text",
+        space = 4.dp,
+        style = textStyle
+    )
+}

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/ui/info/MovieDetailsInfoUI.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/ui/info/MovieDetailsInfoUI.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
@@ -37,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.kirchhoff.movies.core.data.UIGenre
 import com.kirchhoff.movies.core.extensions.BASE_POSTER_PATH
+import com.kirchhoff.movies.core.ui.compose.TextWithIcon
 import com.kirchhoff.movies.core.utils.StringValue
 import com.kirchhoff.movies.screen.movie.R
 import com.kirchhoff.movies.screen.movie.data.UICountry
@@ -84,25 +84,15 @@ internal fun MovieDetailsInfoUI(
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
+                    TextWithIcon(
                         imageVector = Icons.Filled.DateRange,
-                        contentDescription = ""
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        style = infoTextStyle,
                         text = info.releaseDate.orEmpty()
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
+                    TextWithIcon(
                         painter = painterResource(com.kirchhoff.movies.core.R.drawable.ic_access_time),
-                        contentDescription = ""
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        style = infoTextStyle,
                         text = StringValue.IdText(
                             R.string.movie_runtime_format,
                             info.runtime.asMovieRuntime(),


### PR DESCRIPTION
We can't remove code duplication from [`VoteViewComposable`](https://github.com/Kirchhoff-/Movies/blob/master/view/voteview/src/main/java/com/kirchhoff/movies/voteview/VoteViewComposable.kt), cause this module doesn't have access to [`core`](https://github.com/Kirchhoff-/Movies/tree/master/core) module. This problem I described in details here - #675 .

Closes #636 