### PR TITLE
Issue-735: Moved error mapping out of `ReviewListMapper`

### DIFF
--- a/core/src/main/java/com/kirchhoff/movies/core/repository/Result.kt
+++ b/core/src/main/java/com/kirchhoff/movies/core/repository/Result.kt
@@ -30,11 +30,6 @@ sealed class Result<out T> {
             this.code = code
         }
 
-        constructor(code: Int) {
-            this.responseBody = null
-            this.code = code
-        }
-
         override fun toString(): String = "[ApiResponse.Failure $code]: $responseBody"
     }
 
@@ -50,5 +45,11 @@ sealed class Result<out T> {
         }
 
         override fun toString(): String = "[ApiResponse.Failure]: $message"
+    }
+
+    fun <T> mapErrorOrException(): Result<T> = when (this) {
+        is Success -> error("Can't map success result")
+        is Error -> Error(this.responseBody, this.code)
+        is Exception -> Exception(this.message)
     }
 }

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/mapper/ReviewListMapper.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/mapper/ReviewListMapper.kt
@@ -1,36 +1,27 @@
 package com.kirchhoff.movies.screen.review.mapper
 
 import com.kirchhoff.movies.core.mapper.BaseMapper
-import com.kirchhoff.movies.core.repository.Result
 import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.details.review.NetworkReview
 import com.kirchhoff.movies.screen.review.data.UIReview
 
 internal interface IReviewListMapper {
-    fun createUIReviewList(reviewsListResponse: Result<NetworkPaginated<NetworkReview>>): Result<UIPaginated<UIReview>>
+    fun createUIReviewList(reviewsListResponse: NetworkPaginated<NetworkReview>): UIPaginated<UIReview>
 }
 
 internal class ReviewListMapper : BaseMapper(), IReviewListMapper {
 
-    override fun createUIReviewList(reviewsListResponse: Result<NetworkPaginated<NetworkReview>>): Result<UIPaginated<UIReview>> =
-        when (reviewsListResponse) {
-            is Result.Success -> Result.Success(createUIReviewResponse(reviewsListResponse.data))
-            else -> mapErrorOrException(reviewsListResponse)
-        }
+    override fun createUIReviewList(reviewsListResponse: NetworkPaginated<NetworkReview>): UIPaginated<UIReview> = UIPaginated(
+        page = reviewsListResponse.page,
+        results = reviewsListResponse.results.map { it.toUIReview() },
+        totalPages = reviewsListResponse.totalPages
+    )
 
-    private fun createUIReviewResponse(response: NetworkPaginated<NetworkReview>) =
-        UIPaginated(
-            response.page,
-            response.results.map { createUIReview(it) },
-            response.totalPages
-        )
-
-    private fun createUIReview(networkReview: NetworkReview) =
-        UIReview(
-            networkReview.author,
-            networkReview.content,
-            networkReview.authorDetails.avatar,
-            networkReview.authorDetails.rating
-        )
+    private fun NetworkReview.toUIReview(): UIReview = UIReview(
+        author = author,
+        content = content,
+        authorAvatar = authorDetails.avatar,
+        rating = authorDetails.rating
+    )
 }

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/usecase/ReviewUseCase.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/usecase/ReviewUseCase.kt
@@ -23,10 +23,16 @@ internal class ReviewUseCase(
 ) : IReviewUseCase {
 
     override suspend fun fetchMovieReviews(movieId: Int, page: Int): Result<UIPaginated<UIReview>> =
-        reviewMapper.createUIReviewList(reviewRepository.fetchMovieReviews(movieId, page))
+        when (val movieReviews = reviewRepository.fetchMovieReviews(movieId, page)) {
+            is Result.Success -> Result.Success(reviewMapper.createUIReviewList(movieReviews.data))
+            else -> movieReviews.mapErrorOrException()
+        }
 
     override suspend fun fetchTvReviews(tvId: Int, page: Int): Result<UIPaginated<UIReview>> =
-        reviewMapper.createUIReviewList(reviewRepository.fetchTvReviews(tvId, page))
+        when (val movieReviews = reviewRepository.fetchTvReviews(tvId, page)) {
+            is Result.Success -> Result.Success(reviewMapper.createUIReviewList(movieReviews.data))
+            else -> movieReviews.mapErrorOrException()
+        }
 
     override fun movieTitle(movieId: Int): String =
         movieStorage.info(movieId)?.title ?: error("Can't get title for movie with id = $movieId")


### PR DESCRIPTION
Closes #735 

P.S Since we do not often use split for [`Error`](https://github.com/Kirchhoff-/Movies/blob/6595a293bf3c35660af04cdba230f82d2f37f4fe/core/src/main/java/com/kirchhoff/movies/core/repository/Result.kt#L19) and [`Exception`](https://github.com/Kirchhoff-/Movies/blob/6595a293bf3c35660af04cdba230f82d2f37f4fe/core/src/main/java/com/kirchhoff/movies/core/repository/Result.kt#L41) we should consider replacing our [`Result`](https://github.com/Kirchhoff-/Movies/blob/master/core/src/main/java/com/kirchhoff/movies/core/repository/Result.kt) class with default Kotlin `Result`. Correspondent task for this research - #738 