### PR TITLE
Base setup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 
 android {
     compileSdkVersion libs.versions.compileSdk.get().toInteger()
@@ -44,6 +45,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+}
+
+ksp {
+  arg("KOIN_CONFIG_CHECK","true")
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath libs.plugin.kotlin
         classpath libs.plugin.detekt
         classpath libs.plugin.ktlint
+        classpath("com.google.devtools.ksp:symbol-processing-gradle-plugin:1.9.10-1.0.13")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ retrofit = "2.9.0"
 okhttp = "4.10.0"
 gson = "2.10.1"
 
-koin = "3.5.0"
+koin = "4.0.1"
 
 coil = "2.3.0"
 coilCompose = "2.3.0"


### PR DESCRIPTION
Overall, the idea of implementing compile-time safety seems interesting. For many developers, this factor is a decisive one when choosing a particular tool for Dependency Injection.

 A few conclusions from our research:
- For compile-time safety to work correctly, it is necessary to use Koin annotations. We are not big fans of annotations as a programming concept, so for us, this is already a major downside;
- Additionally, to use the plugin that performs the validation, it was necessary to upgrade the versions of many libraries in the application, which requires additional effort.

We are quite satisfied with our current DI implementation and do not see a critical need to switch to Koin Annotations (especially with such overhead).

Theoretically, we could revisit this topic in the future (e.g., as a proof of concept)

Closes #588 