### PR TITLE
Issue-632: The approach to working with the `ExperimentalLayoutApi` annotation has been changed

### DIFF
--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsFragment.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
@@ -46,7 +45,6 @@ internal class MovieDetailsFragment : BaseFragment() {
         viewModel.loadDetails()
     }
 
-    @ExperimentalLayoutApi
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/ui/MovieDetailsUI.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/ui/MovieDetailsUI.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -55,7 +54,6 @@ import com.kirchhoff.movies.screen.movie.ui.screen.details.ui.info.trailers.Movi
 import com.kirchhoff.movies.screen.movie.ui.view.section.MovieSectionUI
 
 @SuppressWarnings("LongParameterList")
-@ExperimentalLayoutApi
 @Composable
 internal fun MovieDetailsUI(
     screenState: MovieDetailsScreenState,
@@ -127,7 +125,6 @@ private fun ShowError(screenState: MovieDetailsScreenState) {
 }
 
 @SuppressWarnings("LongParameterList", "LongMethod")
-@ExperimentalLayoutApi
 @Composable
 private fun ShowUI(
     screenState: MovieDetailsScreenState,
@@ -259,7 +256,6 @@ private fun ShowUI(
     }
 }
 
-@ExperimentalLayoutApi
 @Preview
 @Composable
 private fun MovieDetailsUIPreview() {

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/ui/genre/MovieDetailsGenresUI.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/ui/genre/MovieDetailsGenresUI.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kirchhoff.movies.core.data.ui.UIGenre
 
-@ExperimentalLayoutApi
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun MovieDetailsGenresUI(
     genres: List<UIGenre>,
@@ -27,7 +27,6 @@ internal fun MovieDetailsGenresUI(
     }
 }
 
-@ExperimentalLayoutApi
 @Preview
 @Composable
 private fun MovieDetailsGenresUIPreview() {

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/ui/info/MovieDetailsInfoUI.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/ui/info/MovieDetailsInfoUI.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -45,7 +44,6 @@ import java.util.Date
 import java.util.Locale
 
 @SuppressWarnings("LongMethod")
-@ExperimentalLayoutApi
 @Composable
 internal fun MovieDetailsInfoUI(
     info: UIMovieInfo,
@@ -134,7 +132,6 @@ private fun Int?.asMovieRuntime(): String = if (this != null) {
     ""
 }
 
-@ExperimentalLayoutApi
 @Preview
 @Composable
 private fun MovieDetailsInfoUIPreview() {

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/PersonDetailsFragment.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/PersonDetailsFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
@@ -52,7 +51,6 @@ internal class PersonDetailsFragment : BaseFragment() {
         viewModel.loadDetails()
     }
 
-    @OptIn(ExperimentalLayoutApi::class)
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/ui/PersonDetailsUI.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/ui/PersonDetailsUI.kt
@@ -5,7 +5,6 @@ package com.kirchhoff.movies.screen.person.ui.screen.details.ui
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -35,7 +34,6 @@ import com.kirchhoff.movies.screen.person.ui.screen.details.ui.images.PersonDeta
 import com.kirchhoff.movies.screen.person.ui.screen.details.ui.info.PersonDetailsInfoUI
 import com.kirchhoff.movies.screen.person.ui.screen.details.ui.keywords.PersonDetailsKeywordsUI
 
-@ExperimentalLayoutApi
 @Composable
 internal fun PersonDetailsUI(
     screenState: PersonDetailsScreenState,
@@ -86,7 +84,6 @@ private fun ShowError(screenState: PersonDetailsScreenState) {
     }
 }
 
-@ExperimentalLayoutApi
 @Composable
 private fun ShowUI(
     screenState: PersonDetailsScreenState,
@@ -131,7 +128,6 @@ private fun ShowUI(
     }
 }
 
-@ExperimentalLayoutApi
 @Preview
 @Composable
 private fun PersonDetailsUIPreview() {

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/ui/keywords/PersonDetailsKeywordsItemUI.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/ui/keywords/PersonDetailsKeywordsItemUI.kt
@@ -4,7 +4,6 @@ package com.kirchhoff.movies.screen.person.ui.screen.details.ui.keywords
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
@@ -15,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kirchhoff.movies.core.ui.resources.Colors
 
-@ExperimentalLayoutApi
 @Composable
 internal fun PersonDetailsKeywordsItemUI(text: String) {
     Text(
@@ -34,7 +32,6 @@ internal fun PersonDetailsKeywordsItemUI(text: String) {
     )
 }
 
-@ExperimentalLayoutApi
 @Preview
 @Composable
 private fun PersonDetailsKeywordsItemUIPreview() {

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/ui/keywords/PersonDetailsKeywordsUI.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/ui/keywords/PersonDetailsKeywordsUI.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kirchhoff.movies.core.ui.resources.Colors
 
-@ExperimentalLayoutApi
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun PersonDetailsKeywordsUI(keywords: List<String>) {
     Card(
@@ -35,7 +35,6 @@ internal fun PersonDetailsKeywordsUI(keywords: List<String>) {
     }
 }
 
-@ExperimentalLayoutApi
 @Preview
 @Composable
 private fun PersonDetailsKeywordsUIPreview() {

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/TvShowDetailsFragment.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/TvShowDetailsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
@@ -44,7 +43,6 @@ internal class TvShowDetailsFragment : BaseFragment() {
         viewModel.loadDetails()
     }
 
-    @ExperimentalLayoutApi
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/ui/TvShowDetailsUI.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/ui/TvShowDetailsUI.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -48,7 +47,6 @@ import com.kirchhoff.movies.screen.tvshow.ui.screen.details.ui.keywords.TvShowDe
 import com.kirchhoff.movies.screen.tvshow.ui.view.section.TvShowSectionUI
 
 @SuppressWarnings("LongParameterList")
-@ExperimentalLayoutApi
 @Composable
 internal fun TvShowDetailsUI(
     screenState: TvShowDetailsScreenState,
@@ -103,7 +101,6 @@ private fun ShowError(screenState: TvShowDetailsScreenState) {
     }
 }
 
-@ExperimentalLayoutApi
 @SuppressWarnings("LongMethod")
 @Composable
 private fun ShowUI(
@@ -184,7 +181,6 @@ private fun ShowUI(
     }
 }
 
-@ExperimentalLayoutApi
 @Preview
 @Composable
 private fun TvShowDetailsUIPreview() {

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/ui/keywords/TvShowDetailsKeywordsUI.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/ui/keywords/TvShowDetailsKeywordsUI.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
-@ExperimentalLayoutApi
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun TvShowDetailsKeywordsUI(keywords: List<String>) {
     FlowRow(modifier = Modifier.padding(start = 12.dp)) {
@@ -20,7 +20,6 @@ internal fun TvShowDetailsKeywordsUI(keywords: List<String>) {
     }
 }
 
-@ExperimentalLayoutApi
 @Preview
 @Composable
 private fun TvShowDetailsKeywordsUIPreview() {


### PR DESCRIPTION
We have changed the approach to working with the `ExperimentalLayoutApi` annotation:
- In some places, it was completely removed;
- In others, it was replaced with a more suitable option: `@OptIn(ExperimentalLayoutApi::class)`.

Closes #632 