### PR TITLE
Issue-831: Removed nullable modifier from `NetworkImagesResponse.logos` property

### DIFF
--- a/networkdata/src/main/java/com/kirchhoff/movies/networkdata/core/NetworkImagesResponse.kt
+++ b/networkdata/src/main/java/com/kirchhoff/movies/networkdata/core/NetworkImagesResponse.kt
@@ -5,8 +5,8 @@ import com.kirchhoff.movies.networkdata.main.NetworkImage
 
 data class NetworkImagesResponse(
     @SerializedName("backdrops") val backdrops: List<NetworkImage>,
-    @SerializedName("logos") val logos: List<NetworkImage>?,
+    @SerializedName("logos") val logos: List<NetworkImage>,
     @SerializedName("posters") val posters: List<NetworkImage>
 ) {
-    fun combinedImages(): List<NetworkImage> = backdrops + logos.orEmpty() + posters
+    fun combinedImages(): List<NetworkImage> = backdrops + logos + posters
 }


### PR DESCRIPTION
I couldn't find any confirmation in the documentation that this field can be `null`, so for now we're removing the `nullable` modifier.

Closes #766 