### PR TITLE
Issue-782: Introduce `MovieUseCase` and improve feature structure

### DIFF
--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/MovieModule.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/MovieModule.kt
@@ -12,6 +12,8 @@ import com.kirchhoff.movies.screen.movie.router.IMovieRouter
 import com.kirchhoff.movies.screen.movie.router.MovieRouter
 import com.kirchhoff.movies.screen.movie.storage.IMovieImagesStorage
 import com.kirchhoff.movies.screen.movie.storage.MovieImagesStorage
+import com.kirchhoff.movies.screen.movie.usecase.IMovieUseCase
+import com.kirchhoff.movies.screen.movie.usecase.MovieUseCase
 import org.koin.dsl.module
 import retrofit2.Retrofit
 
@@ -35,5 +37,9 @@ internal val movieModule = module {
             movieImagesStorage = get(),
             movieDetailsMapper = get()
         )
+    }
+
+    single<IMovieUseCase> {
+        MovieUseCase(movieRepository = get())
     }
 }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsModule.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsModule.kt
@@ -20,7 +20,6 @@ internal val movieDetailsModule = module {
 
     single<IMovieDetailsUseCase> {
         MovieDetailsUseCase(
-            movieRepository = get(),
             movieDetailsRepository = get(),
             movieDetailsMapper = get(),
             movieListMapper = get()
@@ -30,7 +29,8 @@ internal val movieDetailsModule = module {
     viewModel { (movieId: MovieId) ->
         MovieDetailsViewModel(
             movieId = movieId,
-            movieDetailsUseCase = get()
+            movieDetailsUseCase = get(),
+            movieUseCase = get()
         )
     }
 }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/usecase/MovieDetailsUseCase.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/usecase/MovieDetailsUseCase.kt
@@ -2,7 +2,6 @@ package com.kirchhoff.movies.screen.movie.ui.screen.details.usecase
 
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.data.ui.UIEntertainmentCredits
-import com.kirchhoff.movies.core.data.ui.UIImage
 import com.kirchhoff.movies.core.data.ui.UIMovie
 import com.kirchhoff.movies.core.repository.Result
 import com.kirchhoff.movies.core.ui.paginated.UIPaginated
@@ -12,7 +11,6 @@ import com.kirchhoff.movies.screen.movie.data.UITrailer
 import com.kirchhoff.movies.screen.movie.mapper.IMovieDetailsMapper
 import com.kirchhoff.movies.screen.movie.mapper.IMovieListMapper
 import com.kirchhoff.movies.screen.movie.repository.IMovieDetailsRepository
-import com.kirchhoff.movies.screen.movie.repository.IMovieRepository
 
 internal interface IMovieDetailsUseCase {
     suspend fun fetchMovie(id: MovieId): kotlin.Result<UIMovie>
@@ -20,11 +18,9 @@ internal interface IMovieDetailsUseCase {
     suspend fun fetchTrailersList(id: MovieId): kotlin.Result<List<UITrailer>>
     suspend fun fetchMovieCredits(id: MovieId): kotlin.Result<UIEntertainmentCredits>
     suspend fun fetchSimilarMovies(id: MovieId, page: Int): kotlin.Result<UIPaginated<UIMovie>>
-    suspend fun fetchImages(id: MovieId): kotlin.Result<List<UIImage>>
 }
 
 internal class MovieDetailsUseCase(
-    private val movieRepository: IMovieRepository,
     private val movieDetailsRepository: IMovieDetailsRepository,
     private val movieDetailsMapper: IMovieDetailsMapper,
     private val movieListMapper: IMovieListMapper
@@ -70,11 +66,5 @@ internal class MovieDetailsUseCase(
         when (val response = movieDetailsRepository.similarMovies(id, page)) {
             is Result.Success -> kotlin.Result.success(movieListMapper.createMovieList(response.data))
             else -> kotlin.Result.failure(Exception("Can't fetch the similar movies"))
-        }
-
-    override suspend fun fetchImages(id: MovieId): kotlin.Result<List<UIImage>> =
-        when (val response = movieRepository.images(id)) {
-            is Result.Success -> kotlin.Result.success(response.data)
-            else -> kotlin.Result.failure(Exception("Can't fetch the images"))
         }
 }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/viewmodel/MovieDetailsViewModel.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/viewmodel/MovieDetailsViewModel.kt
@@ -9,13 +9,15 @@ import com.kirchhoff.movies.core.utils.StringValue
 import com.kirchhoff.movies.screen.movie.R
 import com.kirchhoff.movies.screen.movie.ui.screen.details.model.MovieDetailsScreenState
 import com.kirchhoff.movies.screen.movie.ui.screen.details.usecase.IMovieDetailsUseCase
+import com.kirchhoff.movies.screen.movie.usecase.IMovieUseCase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 
 internal class MovieDetailsViewModel(
     private val movieId: MovieId,
-    private val movieDetailsUseCase: IMovieDetailsUseCase
+    private val movieDetailsUseCase: IMovieDetailsUseCase,
+    private val movieUseCase: IMovieUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<MovieDetailsScreenState> = MutableLiveData()
@@ -89,7 +91,7 @@ internal class MovieDetailsViewModel(
     }
 
     private suspend fun fetchImages() {
-        movieDetailsUseCase.fetchImages(movieId).onSuccess { images ->
+        movieUseCase.fetchImages(movieId).onSuccess { images ->
             val resultImages = if (images.isNotEmpty()) {
                 images.take(DISPLAYING_DATA_AMOUNT)
             } else {

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/MovieImagesModule.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/MovieImagesModule.kt
@@ -1,19 +1,15 @@
 package com.kirchhoff.movies.screen.movie.ui.screen.images
 
 import com.kirchhoff.movies.core.data.MovieId
-import com.kirchhoff.movies.screen.movie.ui.screen.images.usecase.IMovieImagesUseCase
-import com.kirchhoff.movies.screen.movie.ui.screen.images.usecase.MovieImagesUseCase
 import com.kirchhoff.movies.screen.movie.ui.screen.images.viewmodel.MovieImagesViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 internal val movieImagesModule = module {
-    single<IMovieImagesUseCase> { MovieImagesUseCase(movieRepository = get()) }
-
     viewModel { (movieId: MovieId) ->
         MovieImagesViewModel(
             movieId = movieId,
-            movieImagesUseCase = get()
+            movieUseCase = get()
         )
     }
 }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/viewmodel/MovieImagesViewModel.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/viewmodel/MovieImagesViewModel.kt
@@ -5,13 +5,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.screen.movie.ui.screen.images.model.MovieImagesScreenState
-import com.kirchhoff.movies.screen.movie.ui.screen.images.usecase.IMovieImagesUseCase
+import com.kirchhoff.movies.screen.movie.usecase.IMovieUseCase
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 internal class MovieImagesViewModel(
     private val movieId: MovieId,
-    private val movieImagesUseCase: IMovieImagesUseCase
+    private val movieUseCase: IMovieUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<MovieImagesScreenState> = MutableLiveData()
@@ -22,7 +22,7 @@ internal class MovieImagesViewModel(
 
     fun loadImages() {
         viewModelScope.launch {
-            movieImagesUseCase.fetchImages(movieId).fold(
+            movieUseCase.fetchImages(movieId).fold(
                 onSuccess = { data ->
                     screenState.value = screenState.value?.copy(image = data)
                 },

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/usecase/MovieUseCase.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/usecase/MovieUseCase.kt
@@ -1,15 +1,15 @@
-package com.kirchhoff.movies.screen.movie.ui.screen.images.usecase
+package com.kirchhoff.movies.screen.movie.usecase
 
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.data.ui.UIImage
 import com.kirchhoff.movies.core.repository.Result
 import com.kirchhoff.movies.screen.movie.repository.IMovieRepository
 
-internal interface IMovieImagesUseCase {
+internal interface IMovieUseCase {
     suspend fun fetchImages(id: MovieId): kotlin.Result<List<UIImage>>
 }
 
-internal class MovieImagesUseCase(private val movieRepository: IMovieRepository) : IMovieImagesUseCase {
+internal class MovieUseCase(private val movieRepository: IMovieRepository) : IMovieUseCase {
     override suspend fun fetchImages(id: MovieId): kotlin.Result<List<UIImage>> =
         when (val response = movieRepository.images(id)) {
             is Result.Success -> kotlin.Result.success(response.data)


### PR DESCRIPTION
**Context**
Having duplicated logic across UseCases is a bad sign. Each module should have a shared “common” UseCase that contains logic reusable across different screens within the module.

**What was done**
For the `movie` module, a `MovieUseCase` was introduced. Common image loading logic was moved there so it can be reused by multiple screens.

Closes #782