### PR TITLE
Issue-846: Update Detekt config to ignore `@Composable` in `LongMethod`

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -129,6 +129,7 @@ complexity:
   LongMethod:
     active: true
     threshold: 60
+    ignoreAnnotated: ['Composable']
   LongParameterList:
     active: true
     functionThreshold: 6


### PR DESCRIPTION
Closes #846 