### PR TITLE
Issue-849: Remove unnecessary one-to-one interfaces

### DIFF
--- a/app/src/main/java/com/kirchhoff/movies/di/FacadeModule.kt
+++ b/app/src/main/java/com/kirchhoff/movies/di/FacadeModule.kt
@@ -1,21 +1,16 @@
 package com.kirchhoff.movies.di
 
 import com.kirchhoff.movies.screen.credits.CreditsFacade
-import com.kirchhoff.movies.screen.credits.ICreditsFacade
-import com.kirchhoff.movies.screen.movie.IMovieFacade
 import com.kirchhoff.movies.screen.movie.MovieFacade
-import com.kirchhoff.movies.screen.person.IPersonFacade
 import com.kirchhoff.movies.screen.person.PersonFacade
-import com.kirchhoff.movies.screen.review.IReviewFacade
 import com.kirchhoff.movies.screen.review.ReviewFacade
-import com.kirchhoff.movies.screen.tvshow.ITvShowFacade
 import com.kirchhoff.movies.screen.tvshow.TvShowFacade
 import org.koin.dsl.module
 
 val facadeModule = module {
-    single<IMovieFacade> { MovieFacade() }
-    single<ITvShowFacade> { TvShowFacade() }
-    single<IReviewFacade> { ReviewFacade() }
-    single<IPersonFacade> { PersonFacade() }
-    single<ICreditsFacade> { CreditsFacade() }
+    single<MovieFacade> { MovieFacade() }
+    single<TvShowFacade> { TvShowFacade() }
+    single<ReviewFacade> { ReviewFacade() }
+    single<PersonFacade> { PersonFacade() }
+    single<CreditsFacade> { CreditsFacade() }
 }

--- a/app/src/main/java/com/kirchhoff/movies/di/MapperModule.kt
+++ b/app/src/main/java/com/kirchhoff/movies/di/MapperModule.kt
@@ -1,9 +1,8 @@
 package com.kirchhoff.movies.di
 
 import com.kirchhoff.movies.core.mapper.CoreMapper
-import com.kirchhoff.movies.core.mapper.ICoreMapper
 import org.koin.dsl.module
 
 val mapperModule = module {
-    single<ICoreMapper> { CoreMapper() }
+    single<CoreMapper> { CoreMapper() }
 }

--- a/app/src/main/java/com/kirchhoff/movies/router/Router.kt
+++ b/app/src/main/java/com/kirchhoff/movies/router/Router.kt
@@ -5,19 +5,19 @@ import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.core.extensions.replaceFragment
 import com.kirchhoff.movies.core.router.IRouter
-import com.kirchhoff.movies.screen.credits.ICreditsFacade
-import com.kirchhoff.movies.screen.movie.IMovieFacade
-import com.kirchhoff.movies.screen.person.IPersonFacade
-import com.kirchhoff.movies.screen.review.IReviewFacade
-import com.kirchhoff.movies.screen.tvshow.ITvShowFacade
+import com.kirchhoff.movies.screen.credits.CreditsFacade
+import com.kirchhoff.movies.screen.movie.MovieFacade
+import com.kirchhoff.movies.screen.person.PersonFacade
+import com.kirchhoff.movies.screen.review.ReviewFacade
+import com.kirchhoff.movies.screen.tvshow.TvShowFacade
 
 class Router(
     private val activity: AppCompatActivity,
-    private val movieFacade: IMovieFacade,
-    private val tvShowFacade: ITvShowFacade,
-    private val personFacade: IPersonFacade,
-    private val reviewFacade: IReviewFacade,
-    private val creditsFacade: ICreditsFacade
+    private val movieFacade: MovieFacade,
+    private val tvShowFacade: TvShowFacade,
+    private val personFacade: PersonFacade,
+    private val reviewFacade: ReviewFacade,
+    private val creditsFacade: CreditsFacade
 ) : IRouter {
 
     override fun openMovieDetailsScreen(movieId: MovieId) {

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/DashboardModule.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/DashboardModule.kt
@@ -2,11 +2,10 @@ package com.kirchhoff.movies.ui.screens.main
 
 import androidx.appcompat.app.AppCompatActivity
 import com.kirchhoff.movies.ui.screens.main.router.DashboardRouter
-import com.kirchhoff.movies.ui.screens.main.router.IDashboardRouter
 import org.koin.dsl.module
 
 val dashboardModule = module {
-    single<IDashboardRouter> { (activity: AppCompatActivity) ->
+    single<DashboardRouter> { (activity: AppCompatActivity) ->
         DashboardRouter(
             activity,
             movieFacade = get(),

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/MainActivity.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/MainActivity.kt
@@ -5,7 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.kirchhoff.movies.core.ui.utils.viewBinding
 import com.kirchhoff.movies.databinding.ActivityWithFragmentBinding
 import com.kirchhoff.movies.router.routerModule
-import com.kirchhoff.movies.ui.screens.main.router.IDashboardRouter
+import com.kirchhoff.movies.ui.screens.main.router.DashboardRouter
 import org.koin.android.ext.android.inject
 import org.koin.core.context.loadKoinModules
 import org.koin.core.parameter.parametersOf
@@ -14,7 +14,7 @@ class MainActivity : AppCompatActivity() {
 
     private val viewBinding by viewBinding(ActivityWithFragmentBinding::inflate)
 
-    private val dashboardRouter: IDashboardRouter by inject { parametersOf(this) }
+    private val dashboardRouter: DashboardRouter by inject { parametersOf(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         loadKoinModules(routerModule)

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/MainFragment.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/MainFragment.kt
@@ -8,7 +8,7 @@ import com.kirchhoff.movies.R
 import com.kirchhoff.movies.core.ui.BaseFragment
 import com.kirchhoff.movies.core.ui.utils.viewBinding
 import com.kirchhoff.movies.databinding.FragmentMainBinding
-import com.kirchhoff.movies.ui.screens.main.router.IDashboardRouter
+import com.kirchhoff.movies.ui.screens.main.router.DashboardRouter
 import org.koin.android.ext.android.inject
 import org.koin.core.parameter.parametersOf
 
@@ -16,7 +16,7 @@ internal class MainFragment : BaseFragment(R.layout.fragment_main) {
 
     private val viewBinding by viewBinding(FragmentMainBinding::bind)
 
-    private val dashboardRouter: IDashboardRouter by inject { parametersOf(requireActivity()) }
+    private val dashboardRouter: DashboardRouter by inject { parametersOf(requireActivity()) }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/MainPagerAdapter.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/MainPagerAdapter.kt
@@ -3,11 +3,11 @@ package com.kirchhoff.movies.ui.screens.main
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
-import com.kirchhoff.movies.ui.screens.main.router.IDashboardRouter
+import com.kirchhoff.movies.ui.screens.main.router.DashboardRouter
 
 internal class MainPagerAdapter(
     fm: FragmentManager,
-    private val dashboardRouter: IDashboardRouter
+    private val dashboardRouter: DashboardRouter
 ) : FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
     override fun getItem(position: Int): Fragment =

--- a/app/src/main/java/com/kirchhoff/movies/ui/screens/main/router/DashboardRouter.kt
+++ b/app/src/main/java/com/kirchhoff/movies/ui/screens/main/router/DashboardRouter.kt
@@ -3,30 +3,25 @@ package com.kirchhoff.movies.ui.screens.main.router
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.kirchhoff.movies.core.R
-import com.kirchhoff.movies.screen.movie.IMovieFacade
-import com.kirchhoff.movies.screen.person.IPersonFacade
-import com.kirchhoff.movies.screen.tvshow.ITvShowFacade
+import com.kirchhoff.movies.screen.movie.MovieFacade
+import com.kirchhoff.movies.screen.person.PersonFacade
+import com.kirchhoff.movies.screen.tvshow.TvShowFacade
 import com.kirchhoff.movies.ui.screens.main.MainFragment
-
-interface IDashboardRouter {
-    fun openDashboard()
-    fun createScreenForDashboard(position: Int): Fragment
-}
 
 class DashboardRouter(
     private val activity: AppCompatActivity,
-    private val movieFacade: IMovieFacade,
-    private val tvShowFacade: ITvShowFacade,
-    private val personFacade: IPersonFacade
-) : IDashboardRouter {
+    private val movieFacade: MovieFacade,
+    private val tvShowFacade: TvShowFacade,
+    private val personFacade: PersonFacade
+) {
 
-    override fun openDashboard() {
+    fun openDashboard() {
         activity.supportFragmentManager.beginTransaction()
             .replace(R.id.fragmentContainer, MainFragment.newInstance())
             .commit()
     }
 
-    override fun createScreenForDashboard(position: Int): Fragment = when (position) {
+    fun createScreenForDashboard(position: Int): Fragment = when (position) {
         0 -> movieFacade.movieList()
         1 -> tvShowFacade.tvShowList()
         else -> personFacade.personList()

--- a/app/src/test/java/com/kirchhoff/movies/ArchitectureTests.kt
+++ b/app/src/test/java/com/kirchhoff/movies/ArchitectureTests.kt
@@ -3,7 +3,6 @@ package com.kirchhoff.movies
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.ViewModel
 import com.lemonappdev.konsist.api.Konsist
-import com.lemonappdev.konsist.api.ext.list.modifierprovider.withoutSealedModifier
 import com.lemonappdev.konsist.api.ext.list.withAllParentsOf
 import com.lemonappdev.konsist.api.ext.list.withAnnotationOf
 import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
@@ -29,16 +28,6 @@ class ArchitectureTests {
     }
 
     @Test
-    fun `interfaces (not service and listener) should start with 'I'`() {
-        Konsist.scopeFromProject()
-            .interfaces()
-            .withoutSealedModifier()
-            .filterNot { it.hasNameEndingWith("Service") }
-            .filterNot { it.hasNameEndingWith("Listener") }
-            .assert { it.hasNameStartingWith("I") }
-    }
-
-    @Test
     fun `'Service' interfaces shouldn't have parent`() {
         Konsist.scopeFromProject()
             .interfaces()
@@ -47,15 +36,14 @@ class ArchitectureTests {
     }
 
     @Test
-    fun `'Repository' classes should have a corresponding base class and an interface`() {
+    fun `'Repository' classes should have a corresponding base class`() {
         Konsist.scopeFromProject()
             .classes()
             .withNameEndingWith("Repository")
             .filterNot { it.name == "BaseRepository" }
             .assert {
-                it.numParents == 2 &&
-                    it.hasParentWithName("BaseRepository") &&
-                    it.parents.any { parent -> parent.hasNameStartingWith("I") }
+                it.numParents == 1 &&
+                    it.hasParentWithName("BaseRepository")
             }
     }
 
@@ -70,8 +58,9 @@ class ArchitectureTests {
     @Test
     fun `functions in 'Repository' classes should return only the instance of the 'RepositoryResult' class`() {
         Konsist.scopeFromProject()
-            .interfaces()
+            .classes()
             .withNameEndingWith("Repository")
+            .filterNot { klass -> klass.name == "BaseRepository" }
             .assert { interfaceDeclaration ->
                 interfaceDeclaration.containingFile.hasImportWithName("com.kirchhoff.movies.core.repository.RepositoryResult") &&
                     interfaceDeclaration.functions().all { it.returnType?.hasNameStartingWith("RepositoryResult") == true }

--- a/core/src/main/java/com/kirchhoff/movies/core/mapper/CoreMapper.kt
+++ b/core/src/main/java/com/kirchhoff/movies/core/mapper/CoreMapper.kt
@@ -9,30 +9,22 @@ import com.kirchhoff.movies.networkdata.core.NetworkEntertainmentPerson
 import com.kirchhoff.movies.networkdata.core.NetworkObjectWithName
 import com.kirchhoff.movies.networkdata.main.NetworkImage
 
-interface ICoreMapper {
-    fun createUIEntertainmentCredits(credits: NetworkEntertainmentCredits): UIEntertainmentCredits
-    fun createUIEntertainmentActors(actors: List<NetworkEntertainmentPerson.Actor>): List<UIEntertainmentPerson.Actor>
-    fun createUIEntertainmentCreators(creators: List<NetworkEntertainmentPerson.Creator>): List<UIEntertainmentPerson.Creator>
-    fun createUIGenre(item: NetworkObjectWithName): UIGenre
-    fun createUIImage(item: NetworkImage): UIImage
-}
+class CoreMapper : BaseMapper() {
 
-class CoreMapper : BaseMapper(), ICoreMapper {
+    fun createUIEntertainmentCredits(credits: NetworkEntertainmentCredits): UIEntertainmentCredits = credits.toUICredits()
 
-    override fun createUIEntertainmentCredits(credits: NetworkEntertainmentCredits): UIEntertainmentCredits = credits.toUICredits()
+    fun createUIGenre(item: NetworkObjectWithName): UIGenre = UIGenre(item.id, item.name)
 
-    override fun createUIGenre(item: NetworkObjectWithName): UIGenre = UIGenre(item.id, item.name)
-
-    override fun createUIImage(item: NetworkImage): UIImage = UIImage(
+    fun createUIImage(item: NetworkImage): UIImage = UIImage(
         path = item.path,
         height = item.height / IMAGE_SIZE_KF,
         width = item.width / IMAGE_SIZE_KF
     )
 
-    override fun createUIEntertainmentActors(actors: List<NetworkEntertainmentPerson.Actor>): List<UIEntertainmentPerson.Actor> =
+    fun createUIEntertainmentActors(actors: List<NetworkEntertainmentPerson.Actor>): List<UIEntertainmentPerson.Actor> =
         actors.map { it.toUIActor() }
 
-    override fun createUIEntertainmentCreators(creators: List<NetworkEntertainmentPerson.Creator>): List<UIEntertainmentPerson.Creator> =
+    fun createUIEntertainmentCreators(creators: List<NetworkEntertainmentPerson.Creator>): List<UIEntertainmentPerson.Creator> =
         creators.map { it.toUICreator() }
 
     private fun NetworkEntertainmentCredits.toUICredits(): UIEntertainmentCredits = UIEntertainmentCredits(

--- a/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/CreditsFacade.kt
+++ b/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/CreditsFacade.kt
@@ -5,14 +5,8 @@ import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.screen.credits.ui.screen.cast.CreditsCastFragment
 import com.kirchhoff.movies.screen.credits.ui.screen.crew.CreditsCrewFragment
 
-interface ICreditsFacade {
-    fun castCredits(movieId: MovieId): Fragment
-    fun crewCredits(movieId: MovieId): Fragment
-}
+class CreditsFacade {
+    fun castCredits(movieId: MovieId): Fragment = CreditsCastFragment.newInstance(movieId)
 
-class CreditsFacade : ICreditsFacade {
-
-    override fun castCredits(movieId: MovieId): Fragment = CreditsCastFragment.newInstance(movieId)
-
-    override fun crewCredits(movieId: MovieId): Fragment = CreditsCrewFragment.newInstance(movieId)
+    fun crewCredits(movieId: MovieId): Fragment = CreditsCrewFragment.newInstance(movieId)
 }

--- a/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/cast/CreditsCastModule.kt
+++ b/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/cast/CreditsCastModule.kt
@@ -2,13 +2,12 @@ package com.kirchhoff.movies.screen.credits.ui.screen.cast
 
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.screen.credits.ui.screen.cast.usecase.CreditsCastUseCase
-import com.kirchhoff.movies.screen.credits.ui.screen.cast.usecase.ICreditsCastUseCase
 import com.kirchhoff.movies.screen.credits.ui.screen.cast.viewmodel.CreditsCastViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 internal val creditsCastModule = module {
-    single<ICreditsCastUseCase> {
+    single<CreditsCastUseCase> {
         CreditsCastUseCase(
             movieStorage = get(),
             coreMapper = get()

--- a/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/cast/usecase/CreditsCastUseCase.kt
+++ b/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/cast/usecase/CreditsCastUseCase.kt
@@ -2,19 +2,15 @@ package com.kirchhoff.movies.screen.credits.ui.screen.cast.usecase
 
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.data.ui.UIEntertainmentPerson
-import com.kirchhoff.movies.core.mapper.ICoreMapper
-import com.kirchhoff.movies.storage.movie.IStorageMovie
-
-internal interface ICreditsCastUseCase {
-    fun actorsList(movieId: MovieId): List<UIEntertainmentPerson.Actor>
-}
+import com.kirchhoff.movies.core.mapper.CoreMapper
+import com.kirchhoff.movies.storage.movie.StorageMovie
 
 internal class CreditsCastUseCase(
-    private val movieStorage: IStorageMovie,
-    private val coreMapper: ICoreMapper
-) : ICreditsCastUseCase {
+    private val movieStorage: StorageMovie,
+    private val coreMapper: CoreMapper
+) {
 
-    override fun actorsList(movieId: MovieId): List<UIEntertainmentPerson.Actor> {
+    fun actorsList(movieId: MovieId): List<UIEntertainmentPerson.Actor> {
         val actors = movieStorage.credits(movieId.value)?.cast ?: error(
             "There is no info about actors for movie with id = ${movieId.value}"
         )

--- a/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/cast/viewmodel/CreditsCastViewModel.kt
+++ b/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/cast/viewmodel/CreditsCastViewModel.kt
@@ -5,13 +5,13 @@ import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.utils.StringValue
 import com.kirchhoff.movies.screen.credits.R
 import com.kirchhoff.movies.screen.credits.ui.screen.cast.model.CreditsCastScreenState
-import com.kirchhoff.movies.screen.credits.ui.screen.cast.usecase.ICreditsCastUseCase
+import com.kirchhoff.movies.screen.credits.ui.screen.cast.usecase.CreditsCastUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 
 internal class CreditsCastViewModel(
     movieId: MovieId,
-    creditsCastUseCase: ICreditsCastUseCase
+    creditsCastUseCase: CreditsCastUseCase
 ) : ViewModel() {
 
     val screenState: MutableStateFlow<CreditsCastScreenState> = MutableStateFlow(CreditsCastScreenState.Default)

--- a/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/crew/CreditsCrewModule.kt
+++ b/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/crew/CreditsCrewModule.kt
@@ -2,17 +2,15 @@ package com.kirchhoff.movies.screen.credits.ui.screen.crew
 
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.screen.credits.ui.screen.crew.factory.CreditsCrewListFactory
-import com.kirchhoff.movies.screen.credits.ui.screen.crew.factory.ICreditsCrewListFactory
 import com.kirchhoff.movies.screen.credits.ui.screen.crew.usecase.CreditsCrewUseCase
-import com.kirchhoff.movies.screen.credits.ui.screen.crew.usecase.ICreditsCrewUseCase
 import com.kirchhoff.movies.screen.credits.ui.screen.crew.viewmodel.CreditsCrewViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 internal val creditsCrewModule = module {
-    single<ICreditsCrewListFactory> { CreditsCrewListFactory() }
+    single<CreditsCrewListFactory> { CreditsCrewListFactory() }
 
-    single<ICreditsCrewUseCase> {
+    single<CreditsCrewUseCase> {
         CreditsCrewUseCase(
             movieStorage = get(),
             coreMapper = get(),

--- a/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/crew/factory/CreditsCrewListFactory.kt
+++ b/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/crew/factory/CreditsCrewListFactory.kt
@@ -4,15 +4,8 @@ import com.kirchhoff.movies.core.data.ui.UIEntertainmentPerson
 import com.kirchhoff.movies.screen.credits.ui.screen.crew.model.CreditsCrewListItem
 import com.kirchhoff.movies.screen.credits.ui.screen.crew.model.CreditsCrewListPersonItem
 
-internal interface ICreditsCrewListFactory {
+internal class CreditsCrewListFactory {
     fun createCrewList(
-        creators: List<UIEntertainmentPerson.Creator>,
-        expandedItems: Set<String>
-    ): List<CreditsCrewListItem>
-}
-
-internal class CreditsCrewListFactory : ICreditsCrewListFactory {
-    override fun createCrewList(
         creators: List<UIEntertainmentPerson.Creator>,
         expandedItems: Set<String>
     ): List<CreditsCrewListItem> {

--- a/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/crew/usecase/CreditsCrewUseCase.kt
+++ b/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/crew/usecase/CreditsCrewUseCase.kt
@@ -1,22 +1,18 @@
 package com.kirchhoff.movies.screen.credits.ui.screen.crew.usecase
 
 import com.kirchhoff.movies.core.data.MovieId
-import com.kirchhoff.movies.core.mapper.ICoreMapper
-import com.kirchhoff.movies.screen.credits.ui.screen.crew.factory.ICreditsCrewListFactory
+import com.kirchhoff.movies.core.mapper.CoreMapper
+import com.kirchhoff.movies.screen.credits.ui.screen.crew.factory.CreditsCrewListFactory
 import com.kirchhoff.movies.screen.credits.ui.screen.crew.model.CreditsCrewListItem
-import com.kirchhoff.movies.storage.movie.IStorageMovie
-
-internal interface ICreditsCrewUseCase {
-    fun createCrewList(movieId: MovieId, expandedItems: Set<String>): List<CreditsCrewListItem>
-}
+import com.kirchhoff.movies.storage.movie.StorageMovie
 
 internal class CreditsCrewUseCase(
-    private val movieStorage: IStorageMovie,
-    private val coreMapper: ICoreMapper,
-    private val creditsCrewListFactory: ICreditsCrewListFactory
-) : ICreditsCrewUseCase {
+    private val movieStorage: StorageMovie,
+    private val coreMapper: CoreMapper,
+    private val creditsCrewListFactory: CreditsCrewListFactory
+) {
 
-    override fun createCrewList(movieId: MovieId, expandedItems: Set<String>): List<CreditsCrewListItem> {
+    fun createCrewList(movieId: MovieId, expandedItems: Set<String>): List<CreditsCrewListItem> {
         val creators = movieStorage.credits(movieId.value)?.crew ?: error(
             "There is no info about creators for movie with id = ${movieId.value}"
         )

--- a/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/crew/viewmodel/CreditsCrewViewModel.kt
+++ b/screen/credits/src/main/java/com/kirchhoff/movies/screen/credits/ui/screen/crew/viewmodel/CreditsCrewViewModel.kt
@@ -5,13 +5,13 @@ import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.utils.StringValue
 import com.kirchhoff.movies.screen.credits.R
 import com.kirchhoff.movies.screen.credits.ui.screen.crew.model.CreditsCrewScreenState
-import com.kirchhoff.movies.screen.credits.ui.screen.crew.usecase.ICreditsCrewUseCase
+import com.kirchhoff.movies.screen.credits.ui.screen.crew.usecase.CreditsCrewUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 
 internal class CreditsCrewViewModel(
     private val movieId: MovieId,
-    private val creditsCrewUseCase: ICreditsCrewUseCase
+    private val creditsCrewUseCase: CreditsCrewUseCase
 ) : ViewModel() {
 
     val screenState: MutableStateFlow<CreditsCrewScreenState> = MutableStateFlow(CreditsCrewScreenState.Default)

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/MovieFacade.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/MovieFacade.kt
@@ -5,13 +5,8 @@ import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.screen.movie.ui.screen.details.MovieDetailsFragment
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.MovieDiscoverFragment
 
-interface IMovieFacade {
-    fun movieList(): Fragment
-    fun movieDetails(movieId: MovieId): Fragment
-}
+class MovieFacade {
+    fun movieList(): Fragment = MovieDiscoverFragment.newInstance()
 
-class MovieFacade : IMovieFacade {
-    override fun movieList(): Fragment = MovieDiscoverFragment.newInstance()
-
-    override fun movieDetails(movieId: MovieId): Fragment = MovieDetailsFragment.newInstance(movieId)
+    fun movieDetails(movieId: MovieId): Fragment = MovieDetailsFragment.newInstance(movieId)
 }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/MovieModule.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/MovieModule.kt
@@ -1,18 +1,12 @@
 package com.kirchhoff.movies.screen.movie
 
 import androidx.appcompat.app.AppCompatActivity
-import com.kirchhoff.movies.screen.movie.mapper.IMovieDetailsMapper
-import com.kirchhoff.movies.screen.movie.mapper.IMovieListMapper
 import com.kirchhoff.movies.screen.movie.mapper.MovieDetailsMapper
 import com.kirchhoff.movies.screen.movie.mapper.MovieListMapper
 import com.kirchhoff.movies.screen.movie.network.MovieService
-import com.kirchhoff.movies.screen.movie.repository.IMovieRepository
 import com.kirchhoff.movies.screen.movie.repository.MovieRepository
-import com.kirchhoff.movies.screen.movie.router.IMovieRouter
 import com.kirchhoff.movies.screen.movie.router.MovieRouter
-import com.kirchhoff.movies.screen.movie.storage.IMovieImagesStorage
 import com.kirchhoff.movies.screen.movie.storage.MovieImagesStorage
-import com.kirchhoff.movies.screen.movie.usecase.IMovieUseCase
 import com.kirchhoff.movies.screen.movie.usecase.MovieUseCase
 import org.koin.dsl.module
 import retrofit2.Retrofit
@@ -20,17 +14,17 @@ import retrofit2.Retrofit
 internal val movieModule = module {
     single { get<Retrofit>().create(MovieService::class.java) }
 
-    single<IMovieRouter> { (activity: AppCompatActivity) ->
+    single<MovieRouter> { (activity: AppCompatActivity) ->
         MovieRouter(activity)
     }
 
-    single<IMovieDetailsMapper> { MovieDetailsMapper(coreMapper = get()) }
+    single<MovieDetailsMapper> { MovieDetailsMapper(coreMapper = get()) }
 
-    single<IMovieListMapper> { MovieListMapper() }
+    single<MovieListMapper> { MovieListMapper() }
 
-    single<IMovieImagesStorage> { MovieImagesStorage() }
+    single<MovieImagesStorage> { MovieImagesStorage() }
 
-    single<IMovieRepository> {
+    single<MovieRepository> {
         MovieRepository(
             movieService = get(),
             movieStorage = get(),
@@ -39,7 +33,7 @@ internal val movieModule = module {
         )
     }
 
-    single<IMovieUseCase> {
+    single<MovieUseCase> {
         MovieUseCase(movieRepository = get())
     }
 }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/mapper/MovieDetailsMapper.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/mapper/MovieDetailsMapper.kt
@@ -5,7 +5,7 @@ import com.kirchhoff.movies.core.data.ui.UIEntertainmentCredits
 import com.kirchhoff.movies.core.data.ui.UIImage
 import com.kirchhoff.movies.core.data.ui.UIMovie
 import com.kirchhoff.movies.core.mapper.BaseMapper
-import com.kirchhoff.movies.core.mapper.ICoreMapper
+import com.kirchhoff.movies.core.mapper.CoreMapper
 import com.kirchhoff.movies.networkdata.core.NetworkEntertainmentCredits
 import com.kirchhoff.movies.networkdata.core.NetworkImagesResponse
 import com.kirchhoff.movies.networkdata.core.NetworkProductionCompany
@@ -19,27 +19,19 @@ import com.kirchhoff.movies.screen.movie.data.UIMovieInfo
 import com.kirchhoff.movies.screen.movie.data.UIProductionCompany
 import com.kirchhoff.movies.screen.movie.data.UITrailer
 
-internal interface IMovieDetailsMapper {
-    fun createUIMovie(networkMovie: NetworkMovie): UIMovie
-    fun createUIMovieDetails(networkMovieDetails: NetworkMovieDetails): UIMovieInfo
-    fun createUIEntertainmentCredits(networkMovieCredits: NetworkEntertainmentCredits): UIEntertainmentCredits
-    fun createUITrailersList(networkTrailersList: NetworkTrailersList): List<UITrailer>
-    fun createUIImages(networkImagesResponse: NetworkImagesResponse): List<UIImage>
-}
+internal class MovieDetailsMapper(private val coreMapper: CoreMapper) : BaseMapper() {
 
-internal class MovieDetailsMapper(private val coreMapper: ICoreMapper) : BaseMapper(), IMovieDetailsMapper {
+    fun createUIMovie(networkMovie: NetworkMovie): UIMovie = networkMovie.toUIMovie()
 
-    override fun createUIMovie(networkMovie: NetworkMovie): UIMovie = networkMovie.toUIMovie()
+    fun createUIMovieDetails(networkMovieDetails: NetworkMovieDetails): UIMovieInfo = networkMovieDetails.toUIMovie()
 
-    override fun createUIMovieDetails(networkMovieDetails: NetworkMovieDetails): UIMovieInfo = networkMovieDetails.toUIMovie()
-
-    override fun createUIEntertainmentCredits(networkMovieCredits: NetworkEntertainmentCredits): UIEntertainmentCredits =
+    fun createUIEntertainmentCredits(networkMovieCredits: NetworkEntertainmentCredits): UIEntertainmentCredits =
         coreMapper.createUIEntertainmentCredits(networkMovieCredits)
 
-    override fun createUITrailersList(networkTrailersList: NetworkTrailersList): List<UITrailer> =
+    fun createUITrailersList(networkTrailersList: NetworkTrailersList): List<UITrailer> =
         networkTrailersList.toUITrailerList()
 
-    override fun createUIImages(networkImagesResponse: NetworkImagesResponse): List<UIImage> =
+    fun createUIImages(networkImagesResponse: NetworkImagesResponse): List<UIImage> =
         networkImagesResponse.combinedImages().map { coreMapper.createUIImage(it) }
 
     private fun NetworkMovie.toUIMovie(): UIMovie = UIMovie(

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/mapper/MovieListMapper.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/mapper/MovieListMapper.kt
@@ -7,14 +7,9 @@ import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
 
-internal interface IMovieListMapper {
-    fun createMovieList(moviesResponse: NetworkPaginated<NetworkMovie>): UIPaginated<UIMovie>
-}
+internal class MovieListMapper : BaseMapper() {
 
-internal class MovieListMapper : BaseMapper(), IMovieListMapper {
-
-    override fun createMovieList(moviesResponse: NetworkPaginated<NetworkMovie>): UIPaginated<UIMovie> =
-        moviesResponse.toUIPaginated()
+    fun createMovieList(moviesResponse: NetworkPaginated<NetworkMovie>): UIPaginated<UIMovie> = moviesResponse.toUIPaginated()
 
     private fun NetworkPaginated<NetworkMovie>.toUIPaginated(): UIPaginated<UIMovie> = UIPaginated(
         page = page,

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/repository/MovieDetailsRepository.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/repository/MovieDetailsRepository.kt
@@ -9,22 +9,14 @@ import com.kirchhoff.movies.networkdata.details.movie.NetworkMovieDetails
 import com.kirchhoff.movies.networkdata.details.movie.NetworkTrailersList
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
 import com.kirchhoff.movies.screen.movie.network.MovieService
-import com.kirchhoff.movies.storage.movie.IStorageMovie
-
-internal interface IMovieDetailsRepository {
-    suspend fun info(id: MovieId): RepositoryResult<NetworkMovie>
-    suspend fun details(id: MovieId): RepositoryResult<NetworkMovieDetails>
-    suspend fun trailersList(id: MovieId): RepositoryResult<NetworkTrailersList>
-    suspend fun movieCredits(id: MovieId): RepositoryResult<NetworkEntertainmentCredits>
-    suspend fun similarMovies(id: MovieId, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-}
+import com.kirchhoff.movies.storage.movie.StorageMovie
 
 internal class MovieDetailsRepository(
     private val movieService: MovieService,
-    private val movieStorage: IStorageMovie
-) : BaseRepository(), IMovieDetailsRepository {
+    private val movieStorage: StorageMovie
+) : BaseRepository() {
 
-    override suspend fun info(id: MovieId): RepositoryResult<NetworkMovie> {
+    fun info(id: MovieId): RepositoryResult<NetworkMovie> {
         val movieInfo = movieStorage.info(id.value)
 
         return if (movieInfo != null) {
@@ -34,12 +26,12 @@ internal class MovieDetailsRepository(
         }
     }
 
-    override suspend fun details(id: MovieId): RepositoryResult<NetworkMovieDetails> = apiCall { movieService.fetchDetails(id.value) }
+    suspend fun details(id: MovieId): RepositoryResult<NetworkMovieDetails> = apiCall { movieService.fetchDetails(id.value) }
 
-    override suspend fun trailersList(id: MovieId): RepositoryResult<NetworkTrailersList> =
+    suspend fun trailersList(id: MovieId): RepositoryResult<NetworkTrailersList> =
         apiCall { movieService.fetchTrailersList(id.value) }
 
-    override suspend fun movieCredits(id: MovieId): RepositoryResult<NetworkEntertainmentCredits> {
+    suspend fun movieCredits(id: MovieId): RepositoryResult<NetworkEntertainmentCredits> {
         val result = apiCall { movieService.fetchMovieCredits(id.value) }
 
         if (result is RepositoryResult.Success) {
@@ -49,7 +41,7 @@ internal class MovieDetailsRepository(
         return result
     }
 
-    override suspend fun similarMovies(id: MovieId, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> {
+    suspend fun similarMovies(id: MovieId, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> {
         val result = apiCall { movieService.fetchSimilarMovies(id.value, page) }
 
         if (result is RepositoryResult.Success) {

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/repository/MovieRepository.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/repository/MovieRepository.kt
@@ -5,24 +5,19 @@ import com.kirchhoff.movies.core.data.ui.UIImage
 import com.kirchhoff.movies.core.repository.BaseRepository
 import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
-import com.kirchhoff.movies.screen.movie.mapper.IMovieDetailsMapper
+import com.kirchhoff.movies.screen.movie.mapper.MovieDetailsMapper
 import com.kirchhoff.movies.screen.movie.network.MovieService
-import com.kirchhoff.movies.screen.movie.storage.IMovieImagesStorage
-import com.kirchhoff.movies.storage.movie.IStorageMovie
-
-internal interface IMovieRepository {
-    suspend fun info(movieId: MovieId): RepositoryResult<NetworkMovie>
-    suspend fun images(id: MovieId): RepositoryResult<List<UIImage>>
-}
+import com.kirchhoff.movies.screen.movie.storage.MovieImagesStorage
+import com.kirchhoff.movies.storage.movie.StorageMovie
 
 internal class MovieRepository(
     private val movieService: MovieService,
-    private val movieStorage: IStorageMovie,
-    private val movieImagesStorage: IMovieImagesStorage,
-    private val movieDetailsMapper: IMovieDetailsMapper
-) : BaseRepository(), IMovieRepository {
+    private val movieStorage: StorageMovie,
+    private val movieImagesStorage: MovieImagesStorage,
+    private val movieDetailsMapper: MovieDetailsMapper
+) : BaseRepository() {
 
-    override suspend fun info(movieId: MovieId): RepositoryResult<NetworkMovie> {
+    fun info(movieId: MovieId): RepositoryResult<NetworkMovie> {
         val movie = movieStorage.info(movieId.value)
 
         return if (movie != null) {
@@ -32,7 +27,7 @@ internal class MovieRepository(
         }
     }
 
-    override suspend fun images(id: MovieId): RepositoryResult<List<UIImage>> {
+    suspend fun images(id: MovieId): RepositoryResult<List<UIImage>> {
         val localImages = movieImagesStorage.fetchImages(id)
 
         return if (localImages != null) {

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/router/MovieRouter.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/router/MovieRouter.kt
@@ -10,58 +10,45 @@ import com.kirchhoff.movies.screen.movie.ui.screen.image.MovieImageFragment
 import com.kirchhoff.movies.screen.movie.ui.screen.images.MovieImagesFragment
 import com.kirchhoff.movies.screen.movie.ui.screen.list.MovieListFragment
 
-internal interface IMovieRouter {
-    fun openMoviesByGenreScreen(genre: UIGenre)
-    fun openMoviesByCountryScreen(country: UICountry)
-    fun openCompanyMoviesScreen(company: UIProductionCompany)
-    fun openSimilarMoviesScreen(movieId: MovieId)
-    fun openImagesScreen(movieId: MovieId)
-    fun openImage(imagePath: String)
-    fun openNowPlayingScreen()
-    fun openUpcomingScreen()
-    fun openPopularScreen()
-    fun openTopRatedScreen()
-}
+internal class MovieRouter(private val activity: AppCompatActivity) {
 
-internal class MovieRouter(private val activity: AppCompatActivity) : IMovieRouter {
-
-    override fun openMoviesByGenreScreen(genre: UIGenre) {
+    fun openMoviesByGenreScreen(genre: UIGenre) {
         activity.replaceFragment(MovieListFragment.byGenre(genre))
     }
 
-    override fun openMoviesByCountryScreen(country: UICountry) {
+    fun openMoviesByCountryScreen(country: UICountry) {
         activity.replaceFragment(MovieListFragment.byCountry(country))
     }
 
-    override fun openSimilarMoviesScreen(movieId: MovieId) {
+    fun openSimilarMoviesScreen(movieId: MovieId) {
         activity.replaceFragment(MovieListFragment.similarWith(movieId))
     }
 
-    override fun openCompanyMoviesScreen(company: UIProductionCompany) {
+    fun openCompanyMoviesScreen(company: UIProductionCompany) {
         activity.replaceFragment(MovieListFragment.byCompany(company))
     }
 
-    override fun openImagesScreen(movieId: MovieId) {
+    fun openImagesScreen(movieId: MovieId) {
         activity.replaceFragment(MovieImagesFragment.newInstance(movieId))
     }
 
-    override fun openImage(imagePath: String) {
+    fun openImage(imagePath: String) {
         activity.replaceFragment(MovieImageFragment.newInstance(imagePath))
     }
 
-    override fun openNowPlayingScreen() {
+    fun openNowPlayingScreen() {
         activity.replaceFragment(MovieListFragment.nowPlaying())
     }
 
-    override fun openUpcomingScreen() {
+    fun openUpcomingScreen() {
         activity.replaceFragment(MovieListFragment.upcoming())
     }
 
-    override fun openPopularScreen() {
+    fun openPopularScreen() {
         activity.replaceFragment(MovieListFragment.popular())
     }
 
-    override fun openTopRatedScreen() {
+    fun openTopRatedScreen() {
         activity.replaceFragment(MovieListFragment.topRated())
     }
 }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/storage/MovieImagesStorage.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/storage/MovieImagesStorage.kt
@@ -3,18 +3,13 @@ package com.kirchhoff.movies.screen.movie.storage
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.data.ui.UIImage
 
-internal interface IMovieImagesStorage {
-    fun fetchImages(id: MovieId): List<UIImage>?
-    fun updateImages(id: MovieId, images: List<UIImage>)
-}
-
-internal class MovieImagesStorage : IMovieImagesStorage {
+internal class MovieImagesStorage {
 
     private val imagesMap: MutableMap<MovieId, List<UIImage>> = mutableMapOf()
 
-    override fun fetchImages(id: MovieId): List<UIImage>? = imagesMap[id]
+    fun fetchImages(id: MovieId): List<UIImage>? = imagesMap[id]
 
-    override fun updateImages(id: MovieId, images: List<UIImage>) {
+    fun updateImages(id: MovieId, images: List<UIImage>) {
         if (imagesMap.size > MAX_STORAGE_SIZE) {
             imagesMap.remove(imagesMap.keys.first())
         }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsFragment.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsFragment.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.net.toUri
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.ui.BaseFragment
-import com.kirchhoff.movies.screen.movie.router.IMovieRouter
+import com.kirchhoff.movies.screen.movie.router.MovieRouter
 import com.kirchhoff.movies.screen.movie.ui.screen.details.ui.MovieDetailsUI
 import com.kirchhoff.movies.screen.movie.ui.screen.details.viewmodel.MovieDetailsViewModel
 import org.koin.android.ext.android.inject
@@ -30,7 +30,7 @@ internal class MovieDetailsFragment : BaseFragment() {
         MovieId(id)
     }
 
-    private val movieRouter: IMovieRouter by inject { parametersOf(requireActivity()) }
+    private val movieRouter: MovieRouter by inject { parametersOf(requireActivity()) }
 
     private val viewModel: MovieDetailsViewModel by viewModel { parametersOf(movieId) }
 

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsModule.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/MovieDetailsModule.kt
@@ -1,9 +1,7 @@
 package com.kirchhoff.movies.screen.movie.ui.screen.details
 
 import com.kirchhoff.movies.core.data.MovieId
-import com.kirchhoff.movies.screen.movie.repository.IMovieDetailsRepository
 import com.kirchhoff.movies.screen.movie.repository.MovieDetailsRepository
-import com.kirchhoff.movies.screen.movie.ui.screen.details.usecase.IMovieDetailsUseCase
 import com.kirchhoff.movies.screen.movie.ui.screen.details.usecase.MovieDetailsUseCase
 import com.kirchhoff.movies.screen.movie.ui.screen.details.viewmodel.MovieDetailsViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -11,14 +9,14 @@ import org.koin.dsl.module
 
 internal val movieDetailsModule = module {
 
-    single<IMovieDetailsRepository> {
+    single<MovieDetailsRepository> {
         MovieDetailsRepository(
             movieService = get(),
             movieStorage = get()
         )
     }
 
-    single<IMovieDetailsUseCase> {
+    single<MovieDetailsUseCase> {
         MovieDetailsUseCase(
             movieDetailsRepository = get(),
             movieDetailsMapper = get(),

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/usecase/MovieDetailsUseCase.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/usecase/MovieDetailsUseCase.kt
@@ -8,43 +8,35 @@ import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.networkdata.core.NetworkEntertainmentCredits
 import com.kirchhoff.movies.screen.movie.data.UIMovieInfo
 import com.kirchhoff.movies.screen.movie.data.UITrailer
-import com.kirchhoff.movies.screen.movie.mapper.IMovieDetailsMapper
-import com.kirchhoff.movies.screen.movie.mapper.IMovieListMapper
-import com.kirchhoff.movies.screen.movie.repository.IMovieDetailsRepository
-
-internal interface IMovieDetailsUseCase {
-    suspend fun fetchMovie(id: MovieId): Result<UIMovie>
-    suspend fun fetchDetails(id: MovieId): Result<UIMovieInfo>
-    suspend fun fetchTrailersList(id: MovieId): Result<List<UITrailer>>
-    suspend fun fetchMovieCredits(id: MovieId): Result<UIEntertainmentCredits>
-    suspend fun fetchSimilarMovies(id: MovieId, page: Int): Result<UIPaginated<UIMovie>>
-}
+import com.kirchhoff.movies.screen.movie.mapper.MovieDetailsMapper
+import com.kirchhoff.movies.screen.movie.mapper.MovieListMapper
+import com.kirchhoff.movies.screen.movie.repository.MovieDetailsRepository
 
 internal class MovieDetailsUseCase(
-    private val movieDetailsRepository: IMovieDetailsRepository,
-    private val movieDetailsMapper: IMovieDetailsMapper,
-    private val movieListMapper: IMovieListMapper
-) : IMovieDetailsUseCase {
+    private val movieDetailsRepository: MovieDetailsRepository,
+    private val movieDetailsMapper: MovieDetailsMapper,
+    private val movieListMapper: MovieListMapper
+) {
 
-    override suspend fun fetchMovie(id: MovieId): Result<UIMovie> =
+    fun fetchMovie(id: MovieId): Result<UIMovie> =
         when (val response = movieDetailsRepository.info(id)) {
             is RepositoryResult.Success -> Result.success(movieDetailsMapper.createUIMovie(response.data))
             else -> Result.failure(Exception("Can't fetch the movie info"))
         }
 
-    override suspend fun fetchDetails(id: MovieId): Result<UIMovieInfo> =
+    suspend fun fetchDetails(id: MovieId): Result<UIMovieInfo> =
         when (val response = movieDetailsRepository.details(id)) {
             is RepositoryResult.Success -> Result.success(movieDetailsMapper.createUIMovieDetails(response.data))
             else -> Result.failure(Exception("Can't fetch the details"))
         }
 
-    override suspend fun fetchTrailersList(id: MovieId): Result<List<UITrailer>> =
+    suspend fun fetchTrailersList(id: MovieId): Result<List<UITrailer>> =
         when (val response = movieDetailsRepository.trailersList(id)) {
             is RepositoryResult.Success -> Result.success(movieDetailsMapper.createUITrailersList(response.data))
             else -> Result.failure(Exception("Can't fetch the trailers list"))
         }
 
-    override suspend fun fetchMovieCredits(id: MovieId): Result<UIEntertainmentCredits> =
+    suspend fun fetchMovieCredits(id: MovieId): Result<UIEntertainmentCredits> =
         when (val response = movieDetailsRepository.movieCredits(id)) {
             is RepositoryResult.Success -> {
                 Result.success(
@@ -62,7 +54,7 @@ internal class MovieDetailsUseCase(
             else -> Result.failure(Exception("Can't fetch the movie credits"))
         }
 
-    override suspend fun fetchSimilarMovies(id: MovieId, page: Int): Result<UIPaginated<UIMovie>> =
+    suspend fun fetchSimilarMovies(id: MovieId, page: Int): Result<UIPaginated<UIMovie>> =
         when (val response = movieDetailsRepository.similarMovies(id, page)) {
             is RepositoryResult.Success -> Result.success(movieListMapper.createMovieList(response.data))
             else -> Result.failure(Exception("Can't fetch the similar movies"))

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/viewmodel/MovieDetailsViewModel.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/details/viewmodel/MovieDetailsViewModel.kt
@@ -8,16 +8,16 @@ import com.kirchhoff.movies.core.data.ui.UIEntertainmentCredits
 import com.kirchhoff.movies.core.utils.StringValue
 import com.kirchhoff.movies.screen.movie.R
 import com.kirchhoff.movies.screen.movie.ui.screen.details.model.MovieDetailsScreenState
-import com.kirchhoff.movies.screen.movie.ui.screen.details.usecase.IMovieDetailsUseCase
-import com.kirchhoff.movies.screen.movie.usecase.IMovieUseCase
+import com.kirchhoff.movies.screen.movie.ui.screen.details.usecase.MovieDetailsUseCase
+import com.kirchhoff.movies.screen.movie.usecase.MovieUseCase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 
 internal class MovieDetailsViewModel(
     private val movieId: MovieId,
-    private val movieDetailsUseCase: IMovieDetailsUseCase,
-    private val movieUseCase: IMovieUseCase
+    private val movieDetailsUseCase: MovieDetailsUseCase,
+    private val movieUseCase: MovieUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<MovieDetailsScreenState> = MutableLiveData()

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/MovieDiscoverFragment.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/MovieDiscoverFragment.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.kirchhoff.movies.core.ui.BaseFragment
 import com.kirchhoff.movies.screen.movie.movieModule
-import com.kirchhoff.movies.screen.movie.router.IMovieRouter
+import com.kirchhoff.movies.screen.movie.router.MovieRouter
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.ui.MovieDiscoverUI
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.viewmodel.MovieDiscoverViewModel
 import org.koin.android.ext.android.inject
@@ -22,7 +22,7 @@ import org.koin.core.parameter.parametersOf
 
 internal class MovieDiscoverFragment : BaseFragment() {
 
-    private val movieRouter: IMovieRouter by inject { parametersOf(requireActivity()) }
+    private val movieRouter: MovieRouter by inject { parametersOf(requireActivity()) }
 
     private val viewModel: MovieDiscoverViewModel by viewModel()
 

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/MovieDiscoverModule.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/MovieDiscoverModule.kt
@@ -1,11 +1,8 @@
 package com.kirchhoff.movies.screen.movie.ui.screen.discover
 
-import com.kirchhoff.movies.screen.movie.ui.screen.discover.mapper.IMovieDiscoverMapper
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.mapper.MovieDiscoverMapper
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.network.MovieDiscoverService
-import com.kirchhoff.movies.screen.movie.ui.screen.discover.repository.IMovieDiscoverRepository
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.repository.MovieDiscoverRepository
-import com.kirchhoff.movies.screen.movie.ui.screen.discover.usecase.IMovieDiscoverUseCase
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.usecase.MovieDiscoverUseCase
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.viewmodel.MovieDiscoverViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -15,16 +12,16 @@ import retrofit2.Retrofit
 internal val movieDiscoverModule = module {
     single { get<Retrofit>().create(MovieDiscoverService::class.java) }
 
-    single<IMovieDiscoverMapper> { MovieDiscoverMapper() }
+    single<MovieDiscoverMapper> { MovieDiscoverMapper() }
 
-    single<IMovieDiscoverRepository> {
+    single<MovieDiscoverRepository> {
         MovieDiscoverRepository(
             movieDiscoverService = get(),
             movieStorage = get()
         )
     }
 
-    single<IMovieDiscoverUseCase> {
+    single<MovieDiscoverUseCase> {
         MovieDiscoverUseCase(
             movieDiscoverRepository = get(),
             movieDiscoverMapper = get()

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/mapper/MovieDiscoverMapper.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/mapper/MovieDiscoverMapper.kt
@@ -5,12 +5,8 @@ import com.kirchhoff.movies.core.data.ui.UIMovie
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
 
-internal interface IMovieDiscoverMapper {
-    fun mapMovieList(movieList: NetworkPaginated<NetworkMovie>): List<UIMovie>
-}
-
-internal class MovieDiscoverMapper : IMovieDiscoverMapper {
-    override fun mapMovieList(movieList: NetworkPaginated<NetworkMovie>): List<UIMovie> = movieList.results.map { it.toUIMovie() }
+internal class MovieDiscoverMapper {
+    fun mapMovieList(movieList: NetworkPaginated<NetworkMovie>): List<UIMovie> = movieList.results.map { it.toUIMovie() }
 
     private fun NetworkMovie.toUIMovie(): UIMovie = UIMovie(
         id = MovieId(id),

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/repository/MovieDiscoverRepository.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/repository/MovieDiscoverRepository.kt
@@ -5,31 +5,24 @@ import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.network.MovieDiscoverService
-import com.kirchhoff.movies.storage.movie.IStorageMovie
+import com.kirchhoff.movies.storage.movie.StorageMovie
 import retrofit2.Response
-
-internal interface IMovieDiscoverRepository {
-    suspend fun nowPlaying(): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun popular(): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun topRated(): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun upcoming(): RepositoryResult<NetworkPaginated<NetworkMovie>>
-}
 
 internal class MovieDiscoverRepository(
     private val movieDiscoverService: MovieDiscoverService,
-    private val movieStorage: IStorageMovie
-) : BaseRepository(), IMovieDiscoverRepository {
+    private val movieStorage: StorageMovie
+) : BaseRepository() {
 
-    override suspend fun nowPlaying(): RepositoryResult<NetworkPaginated<NetworkMovie>> =
+    suspend fun nowPlaying(): RepositoryResult<NetworkPaginated<NetworkMovie>> =
         fetchMovies { movieDiscoverService.fetchNowPlaying() }
 
-    override suspend fun popular(): RepositoryResult<NetworkPaginated<NetworkMovie>> =
+    suspend fun popular(): RepositoryResult<NetworkPaginated<NetworkMovie>> =
         fetchMovies { movieDiscoverService.fetchPopular() }
 
-    override suspend fun topRated(): RepositoryResult<NetworkPaginated<NetworkMovie>> =
+    suspend fun topRated(): RepositoryResult<NetworkPaginated<NetworkMovie>> =
         fetchMovies { movieDiscoverService.fetchTopRated() }
 
-    override suspend fun upcoming(): RepositoryResult<NetworkPaginated<NetworkMovie>> =
+    suspend fun upcoming(): RepositoryResult<NetworkPaginated<NetworkMovie>> =
         fetchMovies { movieDiscoverService.fetchUpcoming() }
 
     private suspend fun fetchMovies(

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/usecase/MovieDiscoverUseCase.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/usecase/MovieDiscoverUseCase.kt
@@ -4,28 +4,17 @@ import com.kirchhoff.movies.core.data.ui.UIMovie
 import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
-import com.kirchhoff.movies.screen.movie.ui.screen.discover.mapper.IMovieDiscoverMapper
-import com.kirchhoff.movies.screen.movie.ui.screen.discover.repository.IMovieDiscoverRepository
+import com.kirchhoff.movies.screen.movie.ui.screen.discover.mapper.MovieDiscoverMapper
+import com.kirchhoff.movies.screen.movie.ui.screen.discover.repository.MovieDiscoverRepository
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
-internal interface IMovieDiscoverUseCase {
-    suspend fun discoverMovies(): Result
-
-    data class Result(
-        val nowPlaying: List<UIMovie>,
-        val popular: List<UIMovie>,
-        val topRated: List<UIMovie>,
-        val upcoming: List<UIMovie>
-    )
-}
-
 internal class MovieDiscoverUseCase(
-    private val movieDiscoverRepository: IMovieDiscoverRepository,
-    private val movieDiscoverMapper: IMovieDiscoverMapper
-) : IMovieDiscoverUseCase {
+    private val movieDiscoverRepository: MovieDiscoverRepository,
+    private val movieDiscoverMapper: MovieDiscoverMapper
+) {
 
-    override suspend fun discoverMovies(): IMovieDiscoverUseCase.Result {
+    suspend fun discoverMovies(): Result {
         var nowPlaying = emptyList<UIMovie>()
         var popular = emptyList<UIMovie>()
         var topRated = emptyList<UIMovie>()
@@ -38,7 +27,7 @@ internal class MovieDiscoverUseCase(
             launch { upcoming = movieDiscoverRepository.upcoming().toListOrEmpty() }
         }
 
-        return IMovieDiscoverUseCase.Result(
+        return Result(
             nowPlaying = nowPlaying,
             popular = popular,
             topRated = topRated,
@@ -50,4 +39,11 @@ internal class MovieDiscoverUseCase(
         is RepositoryResult.Success -> movieDiscoverMapper.mapMovieList(this.data)
         else -> emptyList()
     }
+
+    data class Result(
+        val nowPlaying: List<UIMovie>,
+        val popular: List<UIMovie>,
+        val topRated: List<UIMovie>,
+        val upcoming: List<UIMovie>
+    )
 }

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/viewmodel/MovieDiscoverViewModel.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/discover/viewmodel/MovieDiscoverViewModel.kt
@@ -4,10 +4,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kirchhoff.movies.screen.movie.ui.screen.discover.model.MovieDiscoverScreenState
-import com.kirchhoff.movies.screen.movie.ui.screen.discover.usecase.IMovieDiscoverUseCase
+import com.kirchhoff.movies.screen.movie.ui.screen.discover.usecase.MovieDiscoverUseCase
 import kotlinx.coroutines.launch
 
-internal class MovieDiscoverViewModel(private val movieDiscoverUseCase: IMovieDiscoverUseCase) : ViewModel() {
+internal class MovieDiscoverViewModel(private val movieDiscoverUseCase: MovieDiscoverUseCase) : ViewModel() {
 
     val screenState: MutableLiveData<MovieDiscoverScreenState> = MutableLiveData()
 

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/MovieImagesFragment.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/MovieImagesFragment.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.ui.BaseFragment
-import com.kirchhoff.movies.screen.movie.router.IMovieRouter
+import com.kirchhoff.movies.screen.movie.router.MovieRouter
 import com.kirchhoff.movies.screen.movie.ui.screen.images.ui.MovieImagesUI
 import com.kirchhoff.movies.screen.movie.ui.screen.images.viewmodel.MovieImagesViewModel
 import org.koin.android.ext.android.inject
@@ -27,7 +27,7 @@ internal class MovieImagesFragment : BaseFragment() {
         if (id == MOVIE_ID_DEFAULT_VALUE) error("Should provide movie id in arguments")
         MovieId(id)
     }
-    private val movieRouter: IMovieRouter by inject { parametersOf(requireActivity()) }
+    private val movieRouter: MovieRouter by inject { parametersOf(requireActivity()) }
 
     private val viewModel: MovieImagesViewModel by viewModel {
         parametersOf(movieId)

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/viewmodel/MovieImagesViewModel.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/images/viewmodel/MovieImagesViewModel.kt
@@ -5,13 +5,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.screen.movie.ui.screen.images.model.MovieImagesScreenState
-import com.kirchhoff.movies.screen.movie.usecase.IMovieUseCase
+import com.kirchhoff.movies.screen.movie.usecase.MovieUseCase
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 internal class MovieImagesViewModel(
     private val movieId: MovieId,
-    private val movieUseCase: IMovieUseCase
+    private val movieUseCase: MovieUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<MovieImagesScreenState> = MutableLiveData()

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/MovieListModule.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/MovieListModule.kt
@@ -1,9 +1,6 @@
 package com.kirchhoff.movies.screen.movie.ui.screen.list
 
-import com.kirchhoff.movies.screen.movie.ui.screen.list.repository.IMovieListRepository
 import com.kirchhoff.movies.screen.movie.ui.screen.list.repository.MovieListRepository
-import com.kirchhoff.movies.screen.movie.ui.screen.list.usecase.IMovieListTitleUseCase
-import com.kirchhoff.movies.screen.movie.ui.screen.list.usecase.IMovieListUseCase
 import com.kirchhoff.movies.screen.movie.ui.screen.list.usecase.MovieListTitleUseCase
 import com.kirchhoff.movies.screen.movie.ui.screen.list.usecase.MovieListUseCase
 import com.kirchhoff.movies.screen.movie.ui.screen.list.viewmodel.MovieListViewModel
@@ -12,21 +9,21 @@ import org.koin.dsl.module
 
 internal val movieListModule = module {
 
-    single<IMovieListRepository> {
+    single<MovieListRepository> {
         MovieListRepository(
             movieService = get(),
             movieStorage = get()
         )
     }
 
-    single<IMovieListUseCase> {
+    single<MovieListUseCase> {
         MovieListUseCase(
             movieListRepository = get(),
             movieListMapper = get()
         )
     }
 
-    single<IMovieListTitleUseCase> {
+    single<MovieListTitleUseCase> {
         MovieListTitleUseCase(movieRepository = get())
     }
 

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/repository/MovieListRepository.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/repository/MovieListRepository.kt
@@ -6,66 +6,55 @@ import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
 import com.kirchhoff.movies.screen.movie.network.MovieService
-import com.kirchhoff.movies.storage.movie.IStorageMovie
+import com.kirchhoff.movies.storage.movie.StorageMovie
 import retrofit2.Response
-
-internal interface IMovieListRepository {
-    suspend fun byGenre(genre: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun byCountry(countryId: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun similar(id: MovieId, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun byCompany(companyId: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun nowPlaying(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun popular(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun topRated(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-    suspend fun upcoming(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>>
-}
 
 internal class MovieListRepository(
     private val movieService: MovieService,
-    private val movieStorage: IStorageMovie
-) : BaseRepository(), IMovieListRepository {
+    private val movieStorage: StorageMovie
+) : BaseRepository() {
 
-    override suspend fun byGenre(genre: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
+    suspend fun byGenre(genre: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
         movieService.fetchByGenre(
             genre = genre,
             page = page
         )
     }
 
-    override suspend fun byCountry(countryId: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
+    suspend fun byCountry(countryId: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
         movieService.fetchByCountry(
             countryId = countryId,
             page = page
         )
     }
 
-    override suspend fun similar(id: MovieId, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
+    suspend fun similar(id: MovieId, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
         movieService.fetchSimilarMovies(
             id = id.value,
             page = page
         )
     }
 
-    override suspend fun byCompany(companyId: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
+    suspend fun byCompany(companyId: String, page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
         movieService.fetchByCompany(
             companyId = companyId,
             page = page
         )
     }
 
-    override suspend fun nowPlaying(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
+    suspend fun nowPlaying(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
         movieService.fetchNowPlaying(page)
     }
 
-    override suspend fun popular(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
+    suspend fun popular(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
         movieService.fetchPopular(page)
     }
 
-    override suspend fun topRated(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
+    suspend fun topRated(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
         movieService.fetchTopRated(page)
     }
 
-    override suspend fun upcoming(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
+    suspend fun upcoming(page: Int): RepositoryResult<NetworkPaginated<NetworkMovie>> = fetchMovies {
         movieService.fetchUpcoming(page)
     }
 

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/usecase/MovieListTitleUseCase.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/usecase/MovieListTitleUseCase.kt
@@ -3,16 +3,12 @@ package com.kirchhoff.movies.screen.movie.ui.screen.list.usecase
 import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.core.utils.StringValue
 import com.kirchhoff.movies.screen.movie.R
-import com.kirchhoff.movies.screen.movie.repository.IMovieRepository
+import com.kirchhoff.movies.screen.movie.repository.MovieRepository
 import com.kirchhoff.movies.screen.movie.ui.screen.list.MovieListType
 
-internal interface IMovieListTitleUseCase {
-    suspend fun title(movieListType: MovieListType): StringValue
-}
+internal class MovieListTitleUseCase(private val movieRepository: MovieRepository) {
 
-internal class MovieListTitleUseCase(private val movieRepository: IMovieRepository) : IMovieListTitleUseCase {
-
-    override suspend fun title(movieListType: MovieListType): StringValue = when (movieListType) {
+    fun title(movieListType: MovieListType): StringValue = when (movieListType) {
         is MovieListType.Genre -> StringValue.IdText(R.string.movie_movies_with_genre_format, movieListType.genre.name)
         is MovieListType.Country -> StringValue.IdText(R.string.movie_movies_from_country_format, movieListType.country.name)
         is MovieListType.Similar -> when (val movieResult = movieRepository.info(movieListType.movieId)) {

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/usecase/MovieListUseCase.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/usecase/MovieListUseCase.kt
@@ -6,63 +6,52 @@ import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
-import com.kirchhoff.movies.screen.movie.mapper.IMovieListMapper
-import com.kirchhoff.movies.screen.movie.ui.screen.list.repository.IMovieListRepository
-
-internal interface IMovieListUseCase {
-    suspend fun fetchByGenre(genre: String, page: Int): Result<UIPaginated<UIMovie>>
-    suspend fun fetchByCountry(countryId: String, page: Int): Result<UIPaginated<UIMovie>>
-    suspend fun fetchSimilarMovies(id: MovieId, page: Int): Result<UIPaginated<UIMovie>>
-    suspend fun fetchByCompany(companyId: String, page: Int): Result<UIPaginated<UIMovie>>
-    suspend fun fetchNowPlaying(page: Int): Result<UIPaginated<UIMovie>>
-    suspend fun fetchPopular(page: Int): Result<UIPaginated<UIMovie>>
-    suspend fun fetchTopRated(page: Int): Result<UIPaginated<UIMovie>>
-    suspend fun fetchUpcoming(page: Int): Result<UIPaginated<UIMovie>>
-}
+import com.kirchhoff.movies.screen.movie.mapper.MovieListMapper
+import com.kirchhoff.movies.screen.movie.ui.screen.list.repository.MovieListRepository
 
 internal class MovieListUseCase(
-    private val movieListRepository: IMovieListRepository,
-    private val movieListMapper: IMovieListMapper
-) : IMovieListUseCase {
+    private val movieListRepository: MovieListRepository,
+    private val movieListMapper: MovieListMapper
+) {
 
-    override suspend fun fetchByGenre(genre: String, page: Int): Result<UIPaginated<UIMovie>> = fetchMovies {
+    suspend fun fetchByGenre(genre: String, page: Int): Result<UIPaginated<UIMovie>> = fetchMovies {
         movieListRepository.byGenre(
             genre = genre,
             page = page
         )
     }
 
-    override suspend fun fetchByCountry(countryId: String, page: Int): Result<UIPaginated<UIMovie>> = fetchMovies {
+    suspend fun fetchByCountry(countryId: String, page: Int): Result<UIPaginated<UIMovie>> = fetchMovies {
         movieListRepository.byCountry(
             countryId = countryId,
             page = page
         )
     }
 
-    override suspend fun fetchSimilarMovies(id: MovieId, page: Int): Result<UIPaginated<UIMovie>> = fetchMovies {
+    suspend fun fetchSimilarMovies(id: MovieId, page: Int): Result<UIPaginated<UIMovie>> = fetchMovies {
         movieListRepository.similar(
             id = id,
             page = page
         )
     }
 
-    override suspend fun fetchByCompany(companyId: String, page: Int): Result<UIPaginated<UIMovie>> = fetchMovies {
+    suspend fun fetchByCompany(companyId: String, page: Int): Result<UIPaginated<UIMovie>> = fetchMovies {
         movieListRepository.byCompany(
             companyId = companyId,
             page = page
         )
     }
 
-    override suspend fun fetchNowPlaying(page: Int): Result<UIPaginated<UIMovie>> =
+    suspend fun fetchNowPlaying(page: Int): Result<UIPaginated<UIMovie>> =
         fetchMovies { movieListRepository.nowPlaying(page) }
 
-    override suspend fun fetchPopular(page: Int): Result<UIPaginated<UIMovie>> =
+    suspend fun fetchPopular(page: Int): Result<UIPaginated<UIMovie>> =
         fetchMovies { movieListRepository.popular(page) }
 
-    override suspend fun fetchTopRated(page: Int): Result<UIPaginated<UIMovie>> =
+    suspend fun fetchTopRated(page: Int): Result<UIPaginated<UIMovie>> =
         fetchMovies { movieListRepository.topRated(page) }
 
-    override suspend fun fetchUpcoming(page: Int): Result<UIPaginated<UIMovie>> =
+    suspend fun fetchUpcoming(page: Int): Result<UIPaginated<UIMovie>> =
         fetchMovies { movieListRepository.upcoming(page) }
 
     private suspend fun fetchMovies(request: suspend () -> RepositoryResult<NetworkPaginated<NetworkMovie>>): Result<UIPaginated<UIMovie>> =

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/viewmodel/MovieListViewModel.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/ui/screen/list/viewmodel/MovieListViewModel.kt
@@ -7,14 +7,14 @@ import com.kirchhoff.movies.core.data.ui.UIMovie
 import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.screen.movie.ui.screen.list.MovieListType
 import com.kirchhoff.movies.screen.movie.ui.screen.list.model.MovieListScreenState
-import com.kirchhoff.movies.screen.movie.ui.screen.list.usecase.IMovieListTitleUseCase
-import com.kirchhoff.movies.screen.movie.ui.screen.list.usecase.IMovieListUseCase
+import com.kirchhoff.movies.screen.movie.ui.screen.list.usecase.MovieListTitleUseCase
+import com.kirchhoff.movies.screen.movie.ui.screen.list.usecase.MovieListUseCase
 import kotlinx.coroutines.launch
 
 internal class MovieListViewModel(
     private val type: MovieListType,
-    private val movieListUseCase: IMovieListUseCase,
-    private val movieListTitleUseCase: IMovieListTitleUseCase
+    private val movieListUseCase: MovieListUseCase,
+    private val movieListTitleUseCase: MovieListTitleUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<MovieListScreenState> = MutableLiveData()

--- a/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/usecase/MovieUseCase.kt
+++ b/screen/movie/src/main/java/com/kirchhoff/movies/screen/movie/usecase/MovieUseCase.kt
@@ -3,14 +3,10 @@ package com.kirchhoff.movies.screen.movie.usecase
 import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.data.ui.UIImage
 import com.kirchhoff.movies.core.repository.RepositoryResult
-import com.kirchhoff.movies.screen.movie.repository.IMovieRepository
+import com.kirchhoff.movies.screen.movie.repository.MovieRepository
 
-internal interface IMovieUseCase {
-    suspend fun fetchImages(id: MovieId): Result<List<UIImage>>
-}
-
-internal class MovieUseCase(private val movieRepository: IMovieRepository) : IMovieUseCase {
-    override suspend fun fetchImages(id: MovieId): Result<List<UIImage>> =
+internal class MovieUseCase(private val movieRepository: MovieRepository) {
+    suspend fun fetchImages(id: MovieId): Result<List<UIImage>> =
         when (val response = movieRepository.images(id)) {
             is RepositoryResult.Success -> Result.success(response.data)
             else -> Result.failure(Exception("Can't fetch the images"))

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/PersonFacade.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/PersonFacade.kt
@@ -4,14 +4,8 @@ import androidx.fragment.app.Fragment
 import com.kirchhoff.movies.screen.person.ui.screen.details.PersonDetailsFragment
 import com.kirchhoff.movies.screen.person.ui.screen.list.PersonListFragment
 
-interface IPersonFacade {
-    fun personList(): Fragment
-    fun personDetails(personId: Int): Fragment
-}
+class PersonFacade {
+    fun personList(): Fragment = PersonListFragment()
 
-class PersonFacade : IPersonFacade {
-
-    override fun personList(): Fragment = PersonListFragment()
-
-    override fun personDetails(personId: Int): Fragment = PersonDetailsFragment.newInstance(personId)
+    fun personDetails(personId: Int): Fragment = PersonDetailsFragment.newInstance(personId)
 }

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/router/PersonRouter.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/router/PersonRouter.kt
@@ -4,12 +4,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.kirchhoff.movies.core.extensions.replaceFragment
 import com.kirchhoff.movies.screen.person.ui.screen.images.PersonImagesFragment
 
-internal interface IPersonRouter {
-    fun openImagesScreen(personId: Int, currentPosition: Int)
-}
-
-internal class PersonRouter(private val activity: AppCompatActivity) : IPersonRouter {
-    override fun openImagesScreen(personId: Int, currentPosition: Int) {
+internal class PersonRouter(private val activity: AppCompatActivity) {
+    fun openImagesScreen(personId: Int, currentPosition: Int) {
         activity.replaceFragment(PersonImagesFragment.newInstance(personId, currentPosition))
     }
 }

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/storage/PersonImagesStorage.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/storage/PersonImagesStorage.kt
@@ -2,18 +2,13 @@ package com.kirchhoff.movies.screen.person.storage
 
 import com.kirchhoff.movies.screen.person.data.UIPersonImage
 
-internal interface IPersonImagesStorage {
-    fun fetchImages(id: Int): List<UIPersonImage>?
-    fun updateImages(id: Int, images: List<UIPersonImage>)
-}
-
-internal class PersonImagesStorage : IPersonImagesStorage {
+internal class PersonImagesStorage {
 
     private val imagesMap: MutableMap<Int, List<UIPersonImage>> = mutableMapOf()
 
-    override fun fetchImages(id: Int): List<UIPersonImage>? = imagesMap[id]
+    fun fetchImages(id: Int): List<UIPersonImage>? = imagesMap[id]
 
-    override fun updateImages(id: Int, images: List<UIPersonImage>) {
+    fun updateImages(id: Int, images: List<UIPersonImage>) {
         if (imagesMap.size > MAX_STORAGE_SIZE) {
             imagesMap.remove(imagesMap.keys.first())
         }

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/PersonDetailsFragment.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/PersonDetailsFragment.kt
@@ -16,7 +16,7 @@ import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.data.TvId
 import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.core.ui.BaseFragment
-import com.kirchhoff.movies.screen.person.router.IPersonRouter
+import com.kirchhoff.movies.screen.person.router.PersonRouter
 import com.kirchhoff.movies.screen.person.ui.screen.details.model.UIMediaType
 import com.kirchhoff.movies.screen.person.ui.screen.details.model.UIPersonCredit
 import com.kirchhoff.movies.screen.person.ui.screen.details.ui.PersonDetailsClickListener
@@ -31,7 +31,7 @@ import timber.log.Timber
 
 internal class PersonDetailsFragment : BaseFragment() {
 
-    private val personRouter: IPersonRouter by inject { parametersOf(requireActivity()) }
+    private val personRouter: PersonRouter by inject { parametersOf(requireActivity()) }
 
     private val viewModel: PersonDetailsViewModel by viewModel { parametersOf(requireArguments().getInt(PERSON_ARG_ID)) }
 

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/PersonDetailsModule.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/PersonDetailsModule.kt
@@ -1,11 +1,8 @@
 package com.kirchhoff.movies.screen.person.ui.screen.details
 
-import com.kirchhoff.movies.screen.person.ui.screen.details.mapper.IPersonDetailsMapper
 import com.kirchhoff.movies.screen.person.ui.screen.details.mapper.PersonDetailsMapper
 import com.kirchhoff.movies.screen.person.ui.screen.details.network.PersonDetailsService
-import com.kirchhoff.movies.screen.person.ui.screen.details.repository.IPersonDetailsRepository
 import com.kirchhoff.movies.screen.person.ui.screen.details.repository.PersonDetailsRepository
-import com.kirchhoff.movies.screen.person.ui.screen.details.usecase.IPersonDetailsUseCase
 import com.kirchhoff.movies.screen.person.ui.screen.details.usecase.PersonDetailsUseCase
 import com.kirchhoff.movies.screen.person.ui.screen.details.viewmodel.PersonDetailsViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -15,15 +12,15 @@ import retrofit2.Retrofit
 internal val personDetailsModule = module {
     single { get<Retrofit>().create(PersonDetailsService::class.java) }
 
-    single<IPersonDetailsRepository> {
+    single<PersonDetailsRepository> {
         PersonDetailsRepository(personDetailsService = get())
     }
 
-    single<IPersonDetailsMapper> {
+    single<PersonDetailsMapper> {
         PersonDetailsMapper()
     }
 
-    single<IPersonDetailsUseCase> {
+    single<PersonDetailsUseCase> {
         PersonDetailsUseCase(
             personDetailsRepository = get(),
             personImageStorage = get(),

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/mapper/PersonDetailsMapper.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/mapper/PersonDetailsMapper.kt
@@ -11,15 +11,9 @@ import com.kirchhoff.movies.screen.person.ui.screen.details.model.UIPersonCredit
 import com.kirchhoff.movies.screen.person.ui.screen.details.model.UIPersonCredits
 import com.kirchhoff.movies.screen.person.ui.screen.details.model.UIPersonDetails
 
-internal interface IPersonDetailsMapper {
-    fun createPersonDetails(personDetails: NetworkPersonDetails): UIPersonDetails
-    fun createCredits(credits: NetworkPersonCredits): UIPersonCredits
-    fun createPersonImage(image: NetworkPersonImage): UIPersonImage
-}
+internal class PersonDetailsMapper {
 
-internal class PersonDetailsMapper : IPersonDetailsMapper {
-
-    override fun createPersonDetails(personDetails: NetworkPersonDetails): UIPersonDetails = UIPersonDetails(
+    fun createPersonDetails(personDetails: NetworkPersonDetails): UIPersonDetails = UIPersonDetails(
         birthday = personDetails.birthday,
         placeOfBirth = personDetails.placeOfBirth,
         biography = personDetails.biography,
@@ -27,12 +21,12 @@ internal class PersonDetailsMapper : IPersonDetailsMapper {
         homepage = personDetails.homepage
     )
 
-    override fun createCredits(credits: NetworkPersonCredits): UIPersonCredits = UIPersonCredits(
+    fun createCredits(credits: NetworkPersonCredits): UIPersonCredits = UIPersonCredits(
         cast = credits.cast?.map { it.toUIPersonCreditActor() },
         crew = credits.crew?.map { it.toUIPersonCreator() }
     )
 
-    override fun createPersonImage(image: NetworkPersonImage): UIPersonImage = UIPersonImage(image.filePath.orEmpty())
+    fun createPersonImage(image: NetworkPersonImage): UIPersonImage = UIPersonImage(image.filePath.orEmpty())
 
     private fun NetworkPersonCastCredit.toUIPersonCreditActor(): UIPersonCredit.Actor = UIPersonCredit.Actor(
         id = id,

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/repository/PersonDetailsRepository.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/repository/PersonDetailsRepository.kt
@@ -7,25 +7,17 @@ import com.kirchhoff.movies.networkdata.details.person.NetworkPersonDetails
 import com.kirchhoff.movies.networkdata.details.person.NetworkPersonImages
 import com.kirchhoff.movies.screen.person.ui.screen.details.network.PersonDetailsService
 
-internal interface IPersonDetailsRepository {
-    suspend fun details(personId: Int): RepositoryResult<NetworkPersonDetails>
-    suspend fun credits(personId: Int): RepositoryResult<NetworkPersonCredits>
-    suspend fun images(personId: Int): RepositoryResult<NetworkPersonImages>
-}
+internal class PersonDetailsRepository(private val personDetailsService: PersonDetailsService) : BaseRepository() {
 
-internal class PersonDetailsRepository(
-    private val personDetailsService: PersonDetailsService
-) : BaseRepository(), IPersonDetailsRepository {
-
-    override suspend fun details(personId: Int): RepositoryResult<NetworkPersonDetails> = apiCall {
+    suspend fun details(personId: Int): RepositoryResult<NetworkPersonDetails> = apiCall {
         personDetailsService.fetchPersonDetail(personId)
     }
 
-    override suspend fun credits(personId: Int): RepositoryResult<NetworkPersonCredits> = apiCall {
+    suspend fun credits(personId: Int): RepositoryResult<NetworkPersonCredits> = apiCall {
         personDetailsService.fetchPersonCredits(personId)
     }
 
-    override suspend fun images(personId: Int): RepositoryResult<NetworkPersonImages> = apiCall {
+    suspend fun images(personId: Int): RepositoryResult<NetworkPersonImages> = apiCall {
         personDetailsService.fetchPersonImages(personId)
     }
 }

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/usecase/PersonDetailsUseCase.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/usecase/PersonDetailsUseCase.kt
@@ -2,37 +2,31 @@ package com.kirchhoff.movies.screen.person.ui.screen.details.usecase
 
 import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.screen.person.data.UIPersonImage
-import com.kirchhoff.movies.screen.person.storage.IPersonImagesStorage
-import com.kirchhoff.movies.screen.person.ui.screen.details.mapper.IPersonDetailsMapper
+import com.kirchhoff.movies.screen.person.storage.PersonImagesStorage
+import com.kirchhoff.movies.screen.person.ui.screen.details.mapper.PersonDetailsMapper
 import com.kirchhoff.movies.screen.person.ui.screen.details.model.UIPersonCredits
 import com.kirchhoff.movies.screen.person.ui.screen.details.model.UIPersonDetails
-import com.kirchhoff.movies.screen.person.ui.screen.details.repository.IPersonDetailsRepository
-
-internal interface IPersonDetailsUseCase {
-    suspend fun fetchDetails(personId: Int): Result<UIPersonDetails>
-    suspend fun fetchCredits(personId: Int): Result<UIPersonCredits>
-    suspend fun fetchImages(personId: Int): Result<List<UIPersonImage>>
-}
+import com.kirchhoff.movies.screen.person.ui.screen.details.repository.PersonDetailsRepository
 
 internal class PersonDetailsUseCase(
-    private val personDetailsRepository: IPersonDetailsRepository,
-    private val personImageStorage: IPersonImagesStorage,
-    private val personDetailsMapper: IPersonDetailsMapper
-) : IPersonDetailsUseCase {
+    private val personDetailsRepository: PersonDetailsRepository,
+    private val personImageStorage: PersonImagesStorage,
+    private val personDetailsMapper: PersonDetailsMapper
+) {
 
-    override suspend fun fetchDetails(personId: Int): Result<UIPersonDetails> =
+    suspend fun fetchDetails(personId: Int): Result<UIPersonDetails> =
         when (val response = personDetailsRepository.details(personId)) {
             is RepositoryResult.Success -> Result.success(personDetailsMapper.createPersonDetails(response.data))
             else -> Result.failure(Exception("Can't fetch the details"))
         }
 
-    override suspend fun fetchCredits(personId: Int): Result<UIPersonCredits> =
+    suspend fun fetchCredits(personId: Int): Result<UIPersonCredits> =
         when (val response = personDetailsRepository.credits(personId)) {
             is RepositoryResult.Success -> Result.success(personDetailsMapper.createCredits(response.data))
             else -> Result.failure(Exception("Can't fetch the credits"))
         }
 
-    override suspend fun fetchImages(personId: Int): Result<List<UIPersonImage>> {
+    suspend fun fetchImages(personId: Int): Result<List<UIPersonImage>> {
         val localImages = personImageStorage.fetchImages(personId)
 
         return if (localImages != null) {

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/viewmodel/PersonDetailsViewModel.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/details/viewmodel/PersonDetailsViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kirchhoff.movies.screen.person.ui.screen.details.model.PersonDetailsScreenState
-import com.kirchhoff.movies.screen.person.ui.screen.details.usecase.IPersonDetailsUseCase
+import com.kirchhoff.movies.screen.person.ui.screen.details.usecase.PersonDetailsUseCase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
@@ -12,7 +12,7 @@ import timber.log.Timber
 
 internal class PersonDetailsViewModel(
     private val personId: Int,
-    private val personDetailsUseCase: IPersonDetailsUseCase
+    private val personDetailsUseCase: PersonDetailsUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<PersonDetailsScreenState> = MutableLiveData()

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/images/PersonImagesModule.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/images/PersonImagesModule.kt
@@ -1,13 +1,12 @@
 package com.kirchhoff.movies.screen.person.ui.screen.images
 
-import com.kirchhoff.movies.screen.person.ui.screen.images.usecase.IPersonImagesUseCase
 import com.kirchhoff.movies.screen.person.ui.screen.images.usecase.PersonImagesUseCase
 import com.kirchhoff.movies.screen.person.ui.screen.images.viewmodel.PersonImagesViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 internal val personImagesModule = module {
-    single<IPersonImagesUseCase> { PersonImagesUseCase(personImagesStorage = get()) }
+    single<PersonImagesUseCase> { PersonImagesUseCase(personImagesStorage = get()) }
 
     viewModel { (personId: Int, startPosition: Int) ->
         PersonImagesViewModel(

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/images/usecase/PersonImagesUseCase.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/images/usecase/PersonImagesUseCase.kt
@@ -1,14 +1,10 @@
 package com.kirchhoff.movies.screen.person.ui.screen.images.usecase
 
 import com.kirchhoff.movies.screen.person.data.UIPersonImage
-import com.kirchhoff.movies.screen.person.storage.IPersonImagesStorage
+import com.kirchhoff.movies.screen.person.storage.PersonImagesStorage
 
-internal interface IPersonImagesUseCase {
-    fun fetchImages(personId: Int): List<UIPersonImage>
-}
-
-internal class PersonImagesUseCase(private val personImagesStorage: IPersonImagesStorage) : IPersonImagesUseCase {
-    override fun fetchImages(personId: Int): List<UIPersonImage> = personImagesStorage.fetchImages(personId) ?: error(
+internal class PersonImagesUseCase(private val personImagesStorage: PersonImagesStorage) {
+    fun fetchImages(personId: Int): List<UIPersonImage> = personImagesStorage.fetchImages(personId) ?: error(
         "There are no images for person with id = $personId"
     )
 }

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/images/viewmodel/PersonImagesViewModel.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/images/viewmodel/PersonImagesViewModel.kt
@@ -3,12 +3,12 @@ package com.kirchhoff.movies.screen.person.ui.screen.images.viewmodel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.kirchhoff.movies.screen.person.ui.screen.images.model.PersonImagesScreenState
-import com.kirchhoff.movies.screen.person.ui.screen.images.usecase.IPersonImagesUseCase
+import com.kirchhoff.movies.screen.person.ui.screen.images.usecase.PersonImagesUseCase
 
 internal class PersonImagesViewModel(
     personId: Int,
     startPosition: Int,
-    personImagesUseCase: IPersonImagesUseCase
+    personImagesUseCase: PersonImagesUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<PersonImagesScreenState> = MutableLiveData()

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/PersonListModule.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/PersonListModule.kt
@@ -1,16 +1,11 @@
 package com.kirchhoff.movies.screen.person.ui.screen.list
 
 import androidx.appcompat.app.AppCompatActivity
-import com.kirchhoff.movies.screen.person.router.IPersonRouter
 import com.kirchhoff.movies.screen.person.router.PersonRouter
-import com.kirchhoff.movies.screen.person.storage.IPersonImagesStorage
 import com.kirchhoff.movies.screen.person.storage.PersonImagesStorage
-import com.kirchhoff.movies.screen.person.ui.screen.list.mapper.IPersonListMapper
 import com.kirchhoff.movies.screen.person.ui.screen.list.mapper.PersonListMapper
 import com.kirchhoff.movies.screen.person.ui.screen.list.network.PersonListService
-import com.kirchhoff.movies.screen.person.ui.screen.list.repository.IPersonListRepository
 import com.kirchhoff.movies.screen.person.ui.screen.list.repository.PersonListRepository
-import com.kirchhoff.movies.screen.person.ui.screen.list.usecase.IPersonListUseCase
 import com.kirchhoff.movies.screen.person.ui.screen.list.usecase.PersonListUseCase
 import com.kirchhoff.movies.screen.person.ui.screen.list.viewmodel.PersonListViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -20,19 +15,19 @@ import retrofit2.Retrofit
 internal val personModule = module {
     single { get<Retrofit>().create(PersonListService::class.java) }
 
-    single<IPersonRouter> { (activity: AppCompatActivity) ->
+    single<PersonRouter> { (activity: AppCompatActivity) ->
         PersonRouter(activity)
     }
 
-    single<IPersonListMapper> { PersonListMapper() }
+    single<PersonListMapper> { PersonListMapper() }
 
-    single<IPersonImagesStorage> { PersonImagesStorage() }
+    single<PersonImagesStorage> { PersonImagesStorage() }
 
-    single<IPersonListRepository> {
+    single<PersonListRepository> {
         PersonListRepository(personListService = get())
     }
 
-    single<IPersonListUseCase> {
+    single<PersonListUseCase> {
         PersonListUseCase(
             personListRepository = get(),
             personListMapper = get()

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/mapper/PersonListMapper.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/mapper/PersonListMapper.kt
@@ -6,13 +6,9 @@ import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkPerson
 
-internal interface IPersonListMapper {
-    fun createUIPersons(personList: NetworkPaginated<NetworkPerson>): UIPaginated<UIPerson>
-}
+internal class PersonListMapper : BaseMapper() {
 
-internal class PersonListMapper : BaseMapper(), IPersonListMapper {
-
-    override fun createUIPersons(personList: NetworkPaginated<NetworkPerson>): UIPaginated<UIPerson> = personList.toUIPaginated()
+    fun createUIPersons(personList: NetworkPaginated<NetworkPerson>): UIPaginated<UIPerson> = personList.toUIPaginated()
 
     private fun NetworkPaginated<NetworkPerson>.toUIPaginated(): UIPaginated<UIPerson> = UIPaginated(
         page = page,

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/repository/PersonListRepository.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/repository/PersonListRepository.kt
@@ -6,13 +6,8 @@ import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkPerson
 import com.kirchhoff.movies.screen.person.ui.screen.list.network.PersonListService
 
-internal interface IPersonListRepository {
-    suspend fun popularPersons(page: Int): RepositoryResult<NetworkPaginated<NetworkPerson>>
-}
-
-internal class PersonListRepository(private val personListService: PersonListService) : BaseRepository(), IPersonListRepository {
-
-    override suspend fun popularPersons(page: Int): RepositoryResult<NetworkPaginated<NetworkPerson>> = apiCall {
+internal class PersonListRepository(private val personListService: PersonListService) : BaseRepository() {
+    suspend fun popularPersons(page: Int): RepositoryResult<NetworkPaginated<NetworkPerson>> = apiCall {
         personListService.fetchPopularPerson(page)
     }
 }

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/usecase/PersonListUseCase.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/usecase/PersonListUseCase.kt
@@ -3,19 +3,15 @@ package com.kirchhoff.movies.screen.person.ui.screen.list.usecase
 import com.kirchhoff.movies.core.data.ui.UIPerson
 import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.core.ui.paginated.UIPaginated
-import com.kirchhoff.movies.screen.person.ui.screen.list.mapper.IPersonListMapper
-import com.kirchhoff.movies.screen.person.ui.screen.list.repository.IPersonListRepository
-
-internal interface IPersonListUseCase {
-    suspend fun fetchPopularPersons(page: Int): Result<UIPaginated<UIPerson>>
-}
+import com.kirchhoff.movies.screen.person.ui.screen.list.mapper.PersonListMapper
+import com.kirchhoff.movies.screen.person.ui.screen.list.repository.PersonListRepository
 
 internal class PersonListUseCase(
-    private val personListRepository: IPersonListRepository,
-    private val personListMapper: IPersonListMapper
-) : IPersonListUseCase {
+    private val personListRepository: PersonListRepository,
+    private val personListMapper: PersonListMapper
+) {
 
-    override suspend fun fetchPopularPersons(page: Int): Result<UIPaginated<UIPerson>> =
+    suspend fun fetchPopularPersons(page: Int): Result<UIPaginated<UIPerson>> =
         when (val response = personListRepository.popularPersons(page)) {
             is RepositoryResult.Success -> Result.success(personListMapper.createUIPersons(response.data))
             else -> Result.failure(Exception("Can't fetch the popular persons"))

--- a/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/viewmodel/PersonListViewModel.kt
+++ b/screen/person/src/main/java/com/kirchhoff/movies/screen/person/ui/screen/list/viewmodel/PersonListViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kirchhoff.movies.core.data.ui.UIPerson
 import com.kirchhoff.movies.screen.person.ui.screen.list.model.PersonListScreenState
-import com.kirchhoff.movies.screen.person.ui.screen.list.usecase.IPersonListUseCase
+import com.kirchhoff.movies.screen.person.ui.screen.list.usecase.PersonListUseCase
 import kotlinx.coroutines.launch
 
-internal class PersonListViewModel(private val personListUseCase: IPersonListUseCase) : ViewModel() {
+internal class PersonListViewModel(private val personListUseCase: PersonListUseCase) : ViewModel() {
 
     val screenState: MutableLiveData<PersonListScreenState> = MutableLiveData()
 

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/ReviewFacade.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/ReviewFacade.kt
@@ -5,13 +5,8 @@ import com.kirchhoff.movies.core.data.MovieId
 import com.kirchhoff.movies.core.data.TvId
 import com.kirchhoff.movies.screen.review.ui.screen.list.ReviewsListFragment
 
-interface IReviewFacade {
-    fun movieReview(id: MovieId): Fragment
-    fun tvShowReview(id: TvId): Fragment
-}
+class ReviewFacade {
+    fun movieReview(id: MovieId): Fragment = ReviewsListFragment.newInstanceForMovie(id)
 
-class ReviewFacade : IReviewFacade {
-    override fun movieReview(id: MovieId): Fragment = ReviewsListFragment.newInstanceForMovie(id)
-
-    override fun tvShowReview(id: TvId): Fragment = ReviewsListFragment.newInstanceForTvShow(id)
+    fun tvShowReview(id: TvId): Fragment = ReviewsListFragment.newInstanceForTvShow(id)
 }

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/ReviewModule.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/ReviewModule.kt
@@ -1,16 +1,12 @@
 package com.kirchhoff.movies.screen.review
 
 import androidx.appcompat.app.AppCompatActivity
-import com.kirchhoff.movies.screen.review.mapper.IReviewListMapper
 import com.kirchhoff.movies.screen.review.mapper.ReviewListMapper
 import com.kirchhoff.movies.screen.review.network.ReviewService
-import com.kirchhoff.movies.screen.review.repository.IReviewRepository
 import com.kirchhoff.movies.screen.review.repository.ReviewRepository
-import com.kirchhoff.movies.screen.review.router.IReviewRouter
 import com.kirchhoff.movies.screen.review.router.ReviewRouter
 import com.kirchhoff.movies.screen.review.ui.screen.list.model.ReviewsListArgs
 import com.kirchhoff.movies.screen.review.ui.screen.list.viewmodel.ReviewsListViewModel
-import com.kirchhoff.movies.screen.review.usecase.IReviewUseCase
 import com.kirchhoff.movies.screen.review.usecase.ReviewUseCase
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -19,17 +15,17 @@ import retrofit2.Retrofit
 internal val reviewModule = module {
     single { get<Retrofit>().create(ReviewService::class.java) }
 
-    single<IReviewRouter> { (activity: AppCompatActivity) ->
+    single<ReviewRouter> { (activity: AppCompatActivity) ->
         ReviewRouter(activity)
     }
 
-    single<IReviewListMapper> { ReviewListMapper() }
+    single<ReviewListMapper> { ReviewListMapper() }
 
-    single<IReviewRepository> {
+    single<ReviewRepository> {
         ReviewRepository(reviewService = get())
     }
 
-    single<IReviewUseCase> {
+    single<ReviewUseCase> {
         ReviewUseCase(
             reviewRepository = get(),
             reviewMapper = get(),

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/mapper/ReviewListMapper.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/mapper/ReviewListMapper.kt
@@ -6,13 +6,9 @@ import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.details.review.NetworkReview
 import com.kirchhoff.movies.screen.review.data.UIReview
 
-internal interface IReviewListMapper {
-    fun createUIReviewList(reviewsListResponse: NetworkPaginated<NetworkReview>): UIPaginated<UIReview>
-}
+internal class ReviewListMapper : BaseMapper() {
 
-internal class ReviewListMapper : BaseMapper(), IReviewListMapper {
-
-    override fun createUIReviewList(reviewsListResponse: NetworkPaginated<NetworkReview>): UIPaginated<UIReview> = UIPaginated(
+    fun createUIReviewList(reviewsListResponse: NetworkPaginated<NetworkReview>): UIPaginated<UIReview> = UIPaginated(
         page = reviewsListResponse.page,
         results = reviewsListResponse.results.map { it.toUIReview() },
         totalPages = reviewsListResponse.totalPages

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/repository/ReviewRepository.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/repository/ReviewRepository.kt
@@ -6,22 +6,14 @@ import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.details.review.NetworkReview
 import com.kirchhoff.movies.screen.review.network.ReviewService
 
-internal interface IReviewRepository {
-    suspend fun movieReviews(movieId: Int, page: Int): RepositoryResult<NetworkPaginated<NetworkReview>>
-    suspend fun rvReviews(tvId: Int, page: Int): RepositoryResult<NetworkPaginated<NetworkReview>>
-}
-
-internal class ReviewRepository(
-    private val reviewService: ReviewService
-) : BaseRepository(), IReviewRepository {
-
-    override suspend fun movieReviews(
+internal class ReviewRepository(private val reviewService: ReviewService) : BaseRepository() {
+    suspend fun movieReviews(
         movieId: Int,
         page: Int
     ): RepositoryResult<NetworkPaginated<NetworkReview>> =
         apiCall { reviewService.movieReviews(movieId, page) }
 
-    override suspend fun rvReviews(
+    suspend fun rvReviews(
         tvId: Int,
         page: Int
     ): RepositoryResult<NetworkPaginated<NetworkReview>> =

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/router/ReviewRouter.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/router/ReviewRouter.kt
@@ -5,12 +5,8 @@ import com.kirchhoff.movies.core.extensions.replaceFragment
 import com.kirchhoff.movies.screen.review.data.UIReview
 import com.kirchhoff.movies.screen.review.ui.screen.details.ReviewDetailsFragment
 
-internal interface IReviewRouter {
-    fun openDetailsScreen(review: UIReview, title: String)
-}
-
-internal class ReviewRouter(private val activity: AppCompatActivity) : IReviewRouter {
-    override fun openDetailsScreen(review: UIReview, title: String) {
+internal class ReviewRouter(private val activity: AppCompatActivity) {
+    fun openDetailsScreen(review: UIReview, title: String) {
         activity.replaceFragment(ReviewDetailsFragment.newInstance(review, title))
     }
 }

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/ui/screen/list/ReviewsListFragment.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/ui/screen/list/ReviewsListFragment.kt
@@ -14,7 +14,7 @@ import com.kirchhoff.movies.core.extensions.getParcelableExtra
 import com.kirchhoff.movies.core.ui.BaseFragment
 import com.kirchhoff.movies.screen.review.data.UIReview
 import com.kirchhoff.movies.screen.review.reviewModule
-import com.kirchhoff.movies.screen.review.router.IReviewRouter
+import com.kirchhoff.movies.screen.review.router.ReviewRouter
 import com.kirchhoff.movies.screen.review.ui.screen.ReviewType
 import com.kirchhoff.movies.screen.review.ui.screen.list.model.ReviewsListArgs
 import com.kirchhoff.movies.screen.review.ui.screen.list.ui.ReviewListUI
@@ -31,7 +31,7 @@ internal class ReviewsListFragment : BaseFragment() {
         requireArguments().getParcelableExtra(REVIEW_ARGS) ?: error("Review argument is not provided")
     }
 
-    private val reviewRouter: IReviewRouter by inject { parametersOf(requireActivity()) }
+    private val reviewRouter: ReviewRouter by inject { parametersOf(requireActivity()) }
 
     private val viewModel: ReviewsListViewModel by viewModel {
         parametersOf(args)

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/ui/screen/list/viewmodel/ReviewsListViewModel.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/ui/screen/list/viewmodel/ReviewsListViewModel.kt
@@ -7,12 +7,12 @@ import com.kirchhoff.movies.screen.review.data.UIReview
 import com.kirchhoff.movies.screen.review.ui.screen.ReviewType
 import com.kirchhoff.movies.screen.review.ui.screen.list.model.ReviewsListArgs
 import com.kirchhoff.movies.screen.review.ui.screen.list.model.ReviewsListScreenState
-import com.kirchhoff.movies.screen.review.usecase.IReviewUseCase
+import com.kirchhoff.movies.screen.review.usecase.ReviewUseCase
 import kotlinx.coroutines.launch
 
 internal class ReviewsListViewModel(
     private val args: ReviewsListArgs,
-    private val useCase: IReviewUseCase
+    private val useCase: ReviewUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<ReviewsListScreenState> = MutableLiveData()

--- a/screen/review/src/main/java/com/kirchhoff/movies/screen/review/usecase/ReviewUseCase.kt
+++ b/screen/review/src/main/java/com/kirchhoff/movies/screen/review/usecase/ReviewUseCase.kt
@@ -3,40 +3,33 @@ package com.kirchhoff.movies.screen.review.usecase
 import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.screen.review.data.UIReview
-import com.kirchhoff.movies.screen.review.mapper.IReviewListMapper
-import com.kirchhoff.movies.screen.review.repository.IReviewRepository
-import com.kirchhoff.movies.storage.movie.IStorageMovie
-import com.kirchhoff.movies.storage.tvshow.IStorageTvShow
-
-internal interface IReviewUseCase {
-    suspend fun fetchMovieReviews(movieId: Int, page: Int): Result<UIPaginated<UIReview>>
-    suspend fun fetchTvReviews(tvId: Int, page: Int): Result<UIPaginated<UIReview>>
-    fun movieTitle(movieId: Int): String
-    fun tvShowTitle(tvShowId: Int): String
-}
+import com.kirchhoff.movies.screen.review.mapper.ReviewListMapper
+import com.kirchhoff.movies.screen.review.repository.ReviewRepository
+import com.kirchhoff.movies.storage.movie.StorageMovie
+import com.kirchhoff.movies.storage.tvshow.StorageTvShow
 
 internal class ReviewUseCase(
-    private val reviewRepository: IReviewRepository,
-    private val reviewMapper: IReviewListMapper,
-    private val movieStorage: IStorageMovie,
-    private val tvShowStorage: IStorageTvShow
-) : IReviewUseCase {
+    private val reviewRepository: ReviewRepository,
+    private val reviewMapper: ReviewListMapper,
+    private val movieStorage: StorageMovie,
+    private val tvShowStorage: StorageTvShow
+) {
 
-    override suspend fun fetchMovieReviews(movieId: Int, page: Int): Result<UIPaginated<UIReview>> =
+    suspend fun fetchMovieReviews(movieId: Int, page: Int): Result<UIPaginated<UIReview>> =
         when (val movieReviews = reviewRepository.movieReviews(movieId, page)) {
             is RepositoryResult.Success -> Result.success(reviewMapper.createUIReviewList(movieReviews.data))
             else -> Result.failure(Exception("Can't get info"))
         }
 
-    override suspend fun fetchTvReviews(tvId: Int, page: Int): Result<UIPaginated<UIReview>> =
+    suspend fun fetchTvReviews(tvId: Int, page: Int): Result<UIPaginated<UIReview>> =
         when (val movieReviews = reviewRepository.rvReviews(tvId, page)) {
             is RepositoryResult.Success -> Result.success(reviewMapper.createUIReviewList(movieReviews.data))
             else -> Result.failure(Exception("Can't get info"))
         }
 
-    override fun movieTitle(movieId: Int): String =
+    fun movieTitle(movieId: Int): String =
         movieStorage.info(movieId)?.title ?: error("Can't get title for movie with id = $movieId")
 
-    override fun tvShowTitle(tvShowId: Int): String =
+    fun tvShowTitle(tvShowId: Int): String =
         tvShowStorage.info(tvShowId)?.name ?: error("Can't get title for tv show with id = $tvShowId")
 }

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/TvShowFacade.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/TvShowFacade.kt
@@ -5,14 +5,9 @@ import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.TvShowDetailsFragment
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.TvShowDiscoverFragment
 
-interface ITvShowFacade {
-    fun tvShowList(): Fragment
-    fun tvShowDetails(tv: UITv): Fragment
-}
+class TvShowFacade {
 
-class TvShowFacade : ITvShowFacade {
+    fun tvShowList(): Fragment = TvShowDiscoverFragment.newInstance()
 
-    override fun tvShowList(): Fragment = TvShowDiscoverFragment.newInstance()
-
-    override fun tvShowDetails(tv: UITv): Fragment = TvShowDetailsFragment.newInstance(tv)
+    fun tvShowDetails(tv: UITv): Fragment = TvShowDetailsFragment.newInstance(tv)
 }

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/router/TvShowRouter.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/router/TvShowRouter.kt
@@ -5,33 +5,25 @@ import com.kirchhoff.movies.core.data.TvId
 import com.kirchhoff.movies.core.extensions.replaceFragment
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.TvShowListFragment
 
-internal interface ITvShowRouter {
-    fun openSimilarTvShowScreen(tvId: TvId)
-    fun openAiringTodayScreen()
-    fun openOnTheAirScreen()
-    fun openPopularScreen()
-    fun openTopRatedScreen()
-}
+internal class TvShowRouter(private val activity: AppCompatActivity) {
 
-internal class TvShowRouter(private val activity: AppCompatActivity) : ITvShowRouter {
-
-    override fun openSimilarTvShowScreen(tvId: TvId) {
+    fun openSimilarTvShowScreen(tvId: TvId) {
         activity.replaceFragment(TvShowListFragment.similar(tvId))
     }
 
-    override fun openAiringTodayScreen() {
+    fun openAiringTodayScreen() {
         activity.replaceFragment(TvShowListFragment.airingToday())
     }
 
-    override fun openOnTheAirScreen() {
+    fun openOnTheAirScreen() {
         activity.replaceFragment(TvShowListFragment.onTheAir())
     }
 
-    override fun openPopularScreen() {
+    fun openPopularScreen() {
         activity.replaceFragment(TvShowListFragment.popular())
     }
 
-    override fun openTopRatedScreen() {
+    fun openTopRatedScreen() {
         activity.replaceFragment(TvShowListFragment.topRated())
     }
 }

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/TvShowDetailsFragment.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/TvShowDetailsFragment.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.core.extensions.getParcelableExtra
 import com.kirchhoff.movies.core.ui.BaseFragment
-import com.kirchhoff.movies.screen.tvshow.router.ITvShowRouter
+import com.kirchhoff.movies.screen.tvshow.router.TvShowRouter
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.ui.TvShowDetailsUI
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.viewmodel.TvShowDetailsViewModel
 import org.koin.android.ext.android.inject
@@ -28,7 +28,7 @@ internal class TvShowDetailsFragment : BaseFragment() {
             ?: error("Should provide tv show info in arguments")
     }
 
-    private val tvShowRouter: ITvShowRouter by inject { parametersOf(requireActivity()) }
+    private val tvShowRouter: TvShowRouter by inject { parametersOf(requireActivity()) }
 
     private val viewModel: TvShowDetailsViewModel by viewModel { parametersOf(tvShow) }
 

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/TvShowDetailsModule.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/TvShowDetailsModule.kt
@@ -2,14 +2,10 @@ package com.kirchhoff.movies.screen.tvshow.ui.screen.details
 
 import androidx.appcompat.app.AppCompatActivity
 import com.kirchhoff.movies.core.data.ui.UITv
-import com.kirchhoff.movies.screen.tvshow.router.ITvShowRouter
 import com.kirchhoff.movies.screen.tvshow.router.TvShowRouter
-import com.kirchhoff.movies.screen.tvshow.ui.screen.details.mapper.ITvShowDetailsMapper
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.mapper.TvShowDetailsMapper
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.network.TvShowDetailsService
-import com.kirchhoff.movies.screen.tvshow.ui.screen.details.repository.ITvShowDetailsRepository
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.repository.TvShowDetailsRepository
-import com.kirchhoff.movies.screen.tvshow.ui.screen.details.usecase.ITvShowDetailsUseCase
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.usecase.TvShowDetailsUseCase
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.viewmodel.TvShowDetailsViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -17,21 +13,21 @@ import org.koin.dsl.module
 import retrofit2.Retrofit
 
 internal val tvShowDetailsModule = module {
-    factory<ITvShowRouter> { (activity: AppCompatActivity) ->
+    factory<TvShowRouter> { (activity: AppCompatActivity) ->
         TvShowRouter(activity)
     }
 
     single { get<Retrofit>().create(TvShowDetailsService::class.java) }
 
-    single<ITvShowDetailsRepository> {
+    single<TvShowDetailsRepository> {
         TvShowDetailsRepository(tvShowDetailsService = get())
     }
 
-    single<ITvShowDetailsMapper> {
+    single<TvShowDetailsMapper> {
         TvShowDetailsMapper(coreMapper = get())
     }
 
-    single<ITvShowDetailsUseCase> {
+    single<TvShowDetailsUseCase> {
         TvShowDetailsUseCase(
             tvShowDetailsRepository = get(),
             tvShowDetailsMapper = get(),

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/mapper/TvShowDetailsMapper.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/mapper/TvShowDetailsMapper.kt
@@ -3,27 +3,22 @@ package com.kirchhoff.movies.screen.tvshow.ui.screen.details.mapper
 import com.kirchhoff.movies.core.data.TvId
 import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.core.mapper.BaseMapper
-import com.kirchhoff.movies.core.mapper.ICoreMapper
+import com.kirchhoff.movies.core.mapper.CoreMapper
 import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.details.tv.NetworkTvDetails
 import com.kirchhoff.movies.networkdata.main.NetworkTv
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.model.TvShowDetails
 
-internal interface ITvShowDetailsMapper {
-    fun createTvShowList(tvShowResponse: NetworkPaginated<NetworkTv>): UIPaginated<UITv>
-    fun createUITvDetails(tvDetails: NetworkTvDetails): TvShowDetails
-}
+internal class TvShowDetailsMapper(private val coreMapper: CoreMapper) : BaseMapper() {
 
-internal class TvShowDetailsMapper(private val coreMapper: ICoreMapper) : BaseMapper(), ITvShowDetailsMapper {
-
-    override fun createTvShowList(tvShowResponse: NetworkPaginated<NetworkTv>): UIPaginated<UITv> = UIPaginated(
+    fun createTvShowList(tvShowResponse: NetworkPaginated<NetworkTv>): UIPaginated<UITv> = UIPaginated(
         page = tvShowResponse.page,
         results = tvShowResponse.results.map { it.toUITv() },
         totalPages = tvShowResponse.totalPages
     )
 
-    override fun createUITvDetails(tvDetails: NetworkTvDetails): TvShowDetails = tvDetails.toTvShowDetailsInfo()
+    fun createUITvDetails(tvDetails: NetworkTvDetails): TvShowDetails = tvDetails.toTvShowDetailsInfo()
 
     private fun NetworkTv.toUITv(): UITv = UITv(
         id = TvId(id),

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/repository/TvShowDetailsRepository.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/repository/TvShowDetailsRepository.kt
@@ -9,22 +9,13 @@ import com.kirchhoff.movies.networkdata.details.tv.NetworkTvDetails
 import com.kirchhoff.movies.networkdata.main.NetworkTv
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.network.TvShowDetailsService
 
-internal interface ITvShowDetailsRepository {
-    suspend fun details(id: TvId): RepositoryResult<NetworkTvDetails>
-    suspend fun similar(id: TvId, page: Int): RepositoryResult<NetworkPaginated<NetworkTv>>
-    suspend fun credits(id: TvId): RepositoryResult<NetworkEntertainmentCredits>
-}
+internal class TvShowDetailsRepository(private val tvShowDetailsService: TvShowDetailsService) : BaseRepository() {
 
-internal class TvShowDetailsRepository(
-    private val tvShowDetailsService: TvShowDetailsService
-) : BaseRepository(), ITvShowDetailsRepository {
-
-    override suspend fun similar(id: TvId, page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> = apiCall {
+    suspend fun similar(id: TvId, page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> = apiCall {
         tvShowDetailsService.fetchSimilarTvShows(id.value, page)
     }
 
-    override suspend fun details(id: TvId): RepositoryResult<NetworkTvDetails> = apiCall { tvShowDetailsService.fetchDetails(id.value) }
+    suspend fun details(id: TvId): RepositoryResult<NetworkTvDetails> = apiCall { tvShowDetailsService.fetchDetails(id.value) }
 
-    override suspend fun credits(id: TvId): RepositoryResult<NetworkEntertainmentCredits> =
-        apiCall { tvShowDetailsService.fetchCredits(id.value) }
+    suspend fun credits(id: TvId): RepositoryResult<NetworkEntertainmentCredits> = apiCall { tvShowDetailsService.fetchCredits(id.value) }
 }

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/usecase/TvShowDetailsUseCase.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/usecase/TvShowDetailsUseCase.kt
@@ -3,38 +3,32 @@ package com.kirchhoff.movies.screen.tvshow.ui.screen.details.usecase
 import com.kirchhoff.movies.core.data.TvId
 import com.kirchhoff.movies.core.data.ui.UIEntertainmentCredits
 import com.kirchhoff.movies.core.data.ui.UITv
-import com.kirchhoff.movies.core.mapper.ICoreMapper
+import com.kirchhoff.movies.core.mapper.CoreMapper
 import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.core.ui.paginated.UIPaginated
-import com.kirchhoff.movies.screen.tvshow.ui.screen.details.mapper.ITvShowDetailsMapper
+import com.kirchhoff.movies.screen.tvshow.ui.screen.details.mapper.TvShowDetailsMapper
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.model.TvShowDetails
-import com.kirchhoff.movies.screen.tvshow.ui.screen.details.repository.ITvShowDetailsRepository
-
-internal interface ITvShowDetailsUseCase {
-    suspend fun fetchDetails(id: TvId): Result<TvShowDetails>
-    suspend fun fetchCredits(id: TvId): Result<UIEntertainmentCredits>
-    suspend fun fetchSimilar(id: TvId, page: Int): Result<UIPaginated<UITv>>
-}
+import com.kirchhoff.movies.screen.tvshow.ui.screen.details.repository.TvShowDetailsRepository
 
 internal class TvShowDetailsUseCase(
-    private val tvShowDetailsRepository: ITvShowDetailsRepository,
-    private val tvShowDetailsMapper: ITvShowDetailsMapper,
-    private val coreMapper: ICoreMapper
-) : ITvShowDetailsUseCase {
+    private val tvShowDetailsRepository: TvShowDetailsRepository,
+    private val tvShowDetailsMapper: TvShowDetailsMapper,
+    private val coreMapper: CoreMapper
+) {
 
-    override suspend fun fetchDetails(id: TvId): Result<TvShowDetails> =
+    suspend fun fetchDetails(id: TvId): Result<TvShowDetails> =
         when (val response = tvShowDetailsRepository.details(id)) {
             is RepositoryResult.Success -> Result.success(tvShowDetailsMapper.createUITvDetails(response.data))
             else -> Result.failure(Exception("Can't fetch the details"))
         }
 
-    override suspend fun fetchCredits(id: TvId): Result<UIEntertainmentCredits> =
+    suspend fun fetchCredits(id: TvId): Result<UIEntertainmentCredits> =
         when (val response = tvShowDetailsRepository.credits(id)) {
             is RepositoryResult.Success -> Result.success(coreMapper.createUIEntertainmentCredits(response.data))
             else -> Result.failure(Exception("Can't fetch the credits"))
         }
 
-    override suspend fun fetchSimilar(id: TvId, page: Int): Result<UIPaginated<UITv>> =
+    suspend fun fetchSimilar(id: TvId, page: Int): Result<UIPaginated<UITv>> =
         when (val response = tvShowDetailsRepository.similar(id, page)) {
             is RepositoryResult.Success -> Result.success(tvShowDetailsMapper.createTvShowList(response.data))
             else -> Result.failure(Exception("Can't fetch the similar tv shows"))

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/viewmodel/TvShowDetailsViewModel.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/details/viewmodel/TvShowDetailsViewModel.kt
@@ -7,7 +7,7 @@ import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.core.utils.StringValue
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.model.TvShowDetailsInfo
 import com.kirchhoff.movies.screen.tvshow.ui.screen.details.model.TvShowDetailsScreenState
-import com.kirchhoff.movies.screen.tvshow.ui.screen.details.usecase.ITvShowDetailsUseCase
+import com.kirchhoff.movies.screen.tvshow.ui.screen.details.usecase.TvShowDetailsUseCase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
@@ -15,7 +15,7 @@ import timber.log.Timber
 
 internal class TvShowDetailsViewModel(
     private val tvShow: UITv,
-    private val tvShowDetailsUseCase: ITvShowDetailsUseCase
+    private val tvShowDetailsUseCase: TvShowDetailsUseCase
 ) : ViewModel() {
 
     val screenState: MutableLiveData<TvShowDetailsScreenState> = MutableLiveData()

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/TvShowDiscoverFragment.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/TvShowDiscoverFragment.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kirchhoff.movies.core.ui.BaseFragment
-import com.kirchhoff.movies.screen.tvshow.router.ITvShowRouter
+import com.kirchhoff.movies.screen.tvshow.router.TvShowRouter
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.ui.TvShowDiscoverUI
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.viewmodel.TvShowDiscoverViewModel
 import org.koin.android.ext.android.inject
@@ -21,7 +21,7 @@ import org.koin.core.parameter.parametersOf
 
 internal class TvShowDiscoverFragment : BaseFragment() {
 
-    private val tvShowRouter: ITvShowRouter by inject { parametersOf(requireActivity()) }
+    private val tvShowRouter: TvShowRouter by inject { parametersOf(requireActivity()) }
 
     private val viewModel: TvShowDiscoverViewModel by viewModel()
 

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/TvShowDiscoverModule.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/TvShowDiscoverModule.kt
@@ -1,14 +1,10 @@
 package com.kirchhoff.movies.screen.tvshow.ui.screen.discover
 
 import androidx.appcompat.app.AppCompatActivity
-import com.kirchhoff.movies.screen.tvshow.router.ITvShowRouter
 import com.kirchhoff.movies.screen.tvshow.router.TvShowRouter
-import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.mapper.ITvShowDiscoverMapper
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.mapper.TvShowDiscoverMapper
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.network.TvShowDiscoverService
-import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.repository.ITvShowDiscoverRepository
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.repository.TvShowDiscoverRepository
-import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.usecase.ITvShowDiscoverUseCase
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.usecase.TvShowDiscoverUseCase
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.viewmodel.TvShowDiscoverViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -16,22 +12,22 @@ import org.koin.dsl.module
 import retrofit2.Retrofit
 
 internal val tvShowDiscoverModule = module {
-    factory<ITvShowRouter> { (activity: AppCompatActivity) ->
+    factory<TvShowRouter> { (activity: AppCompatActivity) ->
         TvShowRouter(activity)
     }
 
     single { get<Retrofit>().create(TvShowDiscoverService::class.java) }
 
-    single<ITvShowDiscoverMapper> { TvShowDiscoverMapper() }
+    single<TvShowDiscoverMapper> { TvShowDiscoverMapper() }
 
-    single<ITvShowDiscoverRepository> {
+    single<TvShowDiscoverRepository> {
         TvShowDiscoverRepository(
             tvShowDiscoverService = get(),
             tvShowStorage = get()
         )
     }
 
-    single<ITvShowDiscoverUseCase> {
+    single<TvShowDiscoverUseCase> {
         TvShowDiscoverUseCase(
             tvShowDiscoverRepository = get(),
             tvShowDiscoverMapper = get()

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/mapper/TvShowDiscoverMapper.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/mapper/TvShowDiscoverMapper.kt
@@ -5,12 +5,8 @@ import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkTv
 
-internal interface ITvShowDiscoverMapper {
-    fun mapTvShowList(tvShowList: NetworkPaginated<NetworkTv>): List<UITv>
-}
-
-internal class TvShowDiscoverMapper : ITvShowDiscoverMapper {
-    override fun mapTvShowList(tvShowList: NetworkPaginated<NetworkTv>): List<UITv> = tvShowList.results.map { it.toUITv() }
+internal class TvShowDiscoverMapper {
+    fun mapTvShowList(tvShowList: NetworkPaginated<NetworkTv>): List<UITv> = tvShowList.results.map { it.toUITv() }
 
     private fun NetworkTv.toUITv(): UITv = UITv(
         id = TvId(id),

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/repository/TvShowDiscoverRepository.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/repository/TvShowDiscoverRepository.kt
@@ -5,31 +5,24 @@ import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkTv
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.network.TvShowDiscoverService
-import com.kirchhoff.movies.storage.tvshow.IStorageTvShow
+import com.kirchhoff.movies.storage.tvshow.StorageTvShow
 import retrofit2.Response
-
-internal interface ITvShowDiscoverRepository {
-    suspend fun airingToday(): RepositoryResult<NetworkPaginated<NetworkTv>>
-    suspend fun onTheAir(): RepositoryResult<NetworkPaginated<NetworkTv>>
-    suspend fun popular(): RepositoryResult<NetworkPaginated<NetworkTv>>
-    suspend fun topRated(): RepositoryResult<NetworkPaginated<NetworkTv>>
-}
 
 internal class TvShowDiscoverRepository(
     private val tvShowDiscoverService: TvShowDiscoverService,
-    private val tvShowStorage: IStorageTvShow
-) : BaseRepository(), ITvShowDiscoverRepository {
+    private val tvShowStorage: StorageTvShow
+) : BaseRepository() {
 
-    override suspend fun airingToday(): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun airingToday(): RepositoryResult<NetworkPaginated<NetworkTv>> =
         fetchTvShows { tvShowDiscoverService.fetchAiringToday() }
 
-    override suspend fun onTheAir(): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun onTheAir(): RepositoryResult<NetworkPaginated<NetworkTv>> =
         fetchTvShows { tvShowDiscoverService.fetchOnTheAir() }
 
-    override suspend fun popular(): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun popular(): RepositoryResult<NetworkPaginated<NetworkTv>> =
         fetchTvShows { tvShowDiscoverService.fetchPopular() }
 
-    override suspend fun topRated(): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun topRated(): RepositoryResult<NetworkPaginated<NetworkTv>> =
         fetchTvShows { tvShowDiscoverService.fetchTopRated() }
 
     private suspend fun fetchTvShows(

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/usecase/TvShowDiscoverUseCase.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/usecase/TvShowDiscoverUseCase.kt
@@ -4,28 +4,17 @@ import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.core.repository.RepositoryResult
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkTv
-import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.mapper.ITvShowDiscoverMapper
-import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.repository.ITvShowDiscoverRepository
+import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.mapper.TvShowDiscoverMapper
+import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.repository.TvShowDiscoverRepository
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
-internal interface ITvShowDiscoverUseCase {
-    suspend fun discoverTvShows(): Result
-
-    data class Result(
-        val airingToday: List<UITv>,
-        val onTheAir: List<UITv>,
-        val popular: List<UITv>,
-        val topRated: List<UITv>
-    )
-}
-
 internal class TvShowDiscoverUseCase(
-    private val tvShowDiscoverRepository: ITvShowDiscoverRepository,
-    private val tvShowDiscoverMapper: ITvShowDiscoverMapper
-) : ITvShowDiscoverUseCase {
+    private val tvShowDiscoverRepository: TvShowDiscoverRepository,
+    private val tvShowDiscoverMapper: TvShowDiscoverMapper
+) {
 
-    override suspend fun discoverTvShows(): ITvShowDiscoverUseCase.Result {
+    suspend fun discoverTvShows(): Result {
         var airingToday = emptyList<UITv>()
         var onTheAir = emptyList<UITv>()
         var popular = emptyList<UITv>()
@@ -38,7 +27,7 @@ internal class TvShowDiscoverUseCase(
             launch { topRated = tvShowDiscoverRepository.topRated().toListOrEmpty() }
         }
 
-        return ITvShowDiscoverUseCase.Result(
+        return Result(
             airingToday = airingToday,
             onTheAir = onTheAir,
             popular = popular,
@@ -50,4 +39,11 @@ internal class TvShowDiscoverUseCase(
         is RepositoryResult.Success -> tvShowDiscoverMapper.mapTvShowList(this.data)
         else -> emptyList()
     }
+
+    data class Result(
+        val airingToday: List<UITv>,
+        val onTheAir: List<UITv>,
+        val popular: List<UITv>,
+        val topRated: List<UITv>
+    )
 }

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/viewmodel/TvShowDiscoverViewModel.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/discover/viewmodel/TvShowDiscoverViewModel.kt
@@ -3,12 +3,12 @@ package com.kirchhoff.movies.screen.tvshow.ui.screen.discover.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.model.TvShowDiscoverScreenState
-import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.usecase.ITvShowDiscoverUseCase
+import com.kirchhoff.movies.screen.tvshow.ui.screen.discover.usecase.TvShowDiscoverUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-internal class TvShowDiscoverViewModel(private val tvShowDiscoverUseCase: ITvShowDiscoverUseCase) : ViewModel() {
+internal class TvShowDiscoverViewModel(private val tvShowDiscoverUseCase: TvShowDiscoverUseCase) : ViewModel() {
 
     val screenState: MutableStateFlow<TvShowDiscoverScreenState> = MutableStateFlow(TvShowDiscoverScreenState.Default)
 

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/TvShowListModule.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/TvShowListModule.kt
@@ -1,14 +1,10 @@
 package com.kirchhoff.movies.screen.tvshow.ui.screen.list
 
 import androidx.appcompat.app.AppCompatActivity
-import com.kirchhoff.movies.screen.tvshow.router.ITvShowRouter
 import com.kirchhoff.movies.screen.tvshow.router.TvShowRouter
-import com.kirchhoff.movies.screen.tvshow.ui.screen.list.mapper.ITvShowListMapper
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.mapper.TvShowListMapper
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.network.TvShowListService
-import com.kirchhoff.movies.screen.tvshow.ui.screen.list.repository.ITvShowListRepository
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.repository.TvShowListRepository
-import com.kirchhoff.movies.screen.tvshow.ui.screen.list.usecase.ITvShowListUseCase
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.usecase.TvShowListUseCase
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.viewmodel.TvShowListViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -17,17 +13,17 @@ import org.koin.dsl.module
 import retrofit2.Retrofit
 
 internal fun tvShowListModule(tvShowListType: TvShowListType): Module = module {
-    factory<ITvShowRouter> { (activity: AppCompatActivity) ->
+    factory<TvShowRouter> { (activity: AppCompatActivity) ->
         TvShowRouter(activity)
     }
 
     single { get<Retrofit>().create(TvShowListService::class.java) }
 
-    single<ITvShowListRepository> { TvShowListRepository(tvShowListService = get()) }
+    single<TvShowListRepository> { TvShowListRepository(tvShowListService = get()) }
 
-    single<ITvShowListMapper> { TvShowListMapper() }
+    single<TvShowListMapper> { TvShowListMapper() }
 
-    single<ITvShowListUseCase> {
+    single<TvShowListUseCase> {
         TvShowListUseCase(
             tvShowListType = tvShowListType,
             tvShowListRepository = get(),

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/mapper/TvShowListMapper.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/mapper/TvShowListMapper.kt
@@ -6,13 +6,9 @@ import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkTv
 
-internal interface ITvShowListMapper {
-    fun createTvShowList(tvShowList: NetworkPaginated<NetworkTv>): UIPaginated<UITv>
-}
+internal class TvShowListMapper {
 
-internal class TvShowListMapper : ITvShowListMapper {
-
-    override fun createTvShowList(tvShowList: NetworkPaginated<NetworkTv>): UIPaginated<UITv> = UIPaginated(
+    fun createTvShowList(tvShowList: NetworkPaginated<NetworkTv>): UIPaginated<UITv> = UIPaginated(
         page = tvShowList.page,
         results = tvShowList.results.map { it.toUITv() },
         totalPages = tvShowList.totalPages

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/repository/TvShowListRepository.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/repository/TvShowListRepository.kt
@@ -7,28 +7,20 @@ import com.kirchhoff.movies.networkdata.core.NetworkPaginated
 import com.kirchhoff.movies.networkdata.main.NetworkTv
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.network.TvShowListService
 
-internal interface ITvShowListRepository {
-    suspend fun similar(id: TvId, page: Int): RepositoryResult<NetworkPaginated<NetworkTv>>
-    suspend fun airingToday(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>>
-    suspend fun onTheAir(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>>
-    suspend fun popular(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>>
-    suspend fun topRated(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>>
-}
+internal class TvShowListRepository(private val tvShowListService: TvShowListService) : BaseRepository() {
 
-internal class TvShowListRepository(private val tvShowListService: TvShowListService) : BaseRepository(), ITvShowListRepository {
-
-    override suspend fun similar(id: TvId, page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun similar(id: TvId, page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
         apiCall { tvShowListService.fetchSimilarTvShows(id.value, page) }
 
-    override suspend fun airingToday(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun airingToday(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
         apiCall { tvShowListService.fetchAiringToday(page) }
 
-    override suspend fun onTheAir(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun onTheAir(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
         apiCall { tvShowListService.fetchOnTheAir(page) }
 
-    override suspend fun popular(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun popular(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
         apiCall { tvShowListService.fetchPopular(page) }
 
-    override suspend fun topRated(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
+    suspend fun topRated(page: Int): RepositoryResult<NetworkPaginated<NetworkTv>> =
         apiCall { tvShowListService.fetchTopRated(page) }
 }

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/usecase/TvShowListUseCase.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/usecase/TvShowListUseCase.kt
@@ -6,21 +6,16 @@ import com.kirchhoff.movies.core.ui.paginated.UIPaginated
 import com.kirchhoff.movies.core.utils.StringValue
 import com.kirchhoff.movies.screen.tvshow.R
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.TvShowListType
-import com.kirchhoff.movies.screen.tvshow.ui.screen.list.mapper.ITvShowListMapper
-import com.kirchhoff.movies.screen.tvshow.ui.screen.list.repository.ITvShowListRepository
-
-internal interface ITvShowListUseCase {
-    suspend fun load(page: Int): Result<UIPaginated<UITv>>
-    fun title(): StringValue
-}
+import com.kirchhoff.movies.screen.tvshow.ui.screen.list.mapper.TvShowListMapper
+import com.kirchhoff.movies.screen.tvshow.ui.screen.list.repository.TvShowListRepository
 
 internal class TvShowListUseCase(
     private val tvShowListType: TvShowListType,
-    private val tvShowListRepository: ITvShowListRepository,
-    private val tvShowListMapper: ITvShowListMapper
-) : ITvShowListUseCase {
+    private val tvShowListRepository: TvShowListRepository,
+    private val tvShowListMapper: TvShowListMapper
+) {
 
-    override suspend fun load(page: Int): Result<UIPaginated<UITv>> {
+    suspend fun load(page: Int): Result<UIPaginated<UITv>> {
         val result = when (tvShowListType) {
             is TvShowListType.Similar -> tvShowListRepository.similar(tvShowListType.id, page)
             is TvShowListType.AiringToday -> tvShowListRepository.airingToday(page)
@@ -36,7 +31,7 @@ internal class TvShowListUseCase(
         }
     }
 
-    override fun title(): StringValue = when (tvShowListType) {
+    fun title(): StringValue = when (tvShowListType) {
         is TvShowListType.Similar -> StringValue.IdText(R.string.similar_tv_shows)
         is TvShowListType.AiringToday -> StringValue.IdText(R.string.tv_show_airing_today)
         is TvShowListType.OnTheAir -> StringValue.IdText(R.string.tv_show_on_the_air)

--- a/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/viewmodel/TvShowListViewModel.kt
+++ b/screen/tvshow/src/main/java/com/kirchhoff/movies/screen/tvshow/ui/screen/list/viewmodel/TvShowListViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kirchhoff.movies.core.data.ui.UITv
 import com.kirchhoff.movies.screen.tvshow.ui.screen.list.model.TvShowListScreenState
-import com.kirchhoff.movies.screen.tvshow.ui.screen.list.usecase.ITvShowListUseCase
+import com.kirchhoff.movies.screen.tvshow.ui.screen.list.usecase.TvShowListUseCase
 import kotlinx.coroutines.launch
 
-internal class TvShowListViewModel(private val tvShowListUseCase: ITvShowListUseCase) : ViewModel() {
+internal class TvShowListViewModel(private val tvShowListUseCase: TvShowListUseCase) : ViewModel() {
 
     val screenState: MutableLiveData<TvShowListScreenState> = MutableLiveData()
 

--- a/storage/movie/src/main/java/com/kirchhoff/movies/storage/movie/StorageMovie.kt
+++ b/storage/movie/src/main/java/com/kirchhoff/movies/storage/movie/StorageMovie.kt
@@ -3,26 +3,19 @@ package com.kirchhoff.movies.storage.movie
 import com.kirchhoff.movies.networkdata.core.NetworkEntertainmentCredits
 import com.kirchhoff.movies.networkdata.main.NetworkMovie
 
-interface IStorageMovie {
-    fun updateInfo(movie: NetworkMovie)
-    fun info(movieId: Int): NetworkMovie?
-    fun updateCredits(movieId: Int, credits: NetworkEntertainmentCredits)
-    fun credits(movieId: Int): NetworkEntertainmentCredits?
-}
-
-internal class StorageMovie : IStorageMovie {
+class StorageMovie {
     private val moviesCache: MutableMap<Int, NetworkMovie> = HashMap()
     private val creditsCache: MutableMap<Int, NetworkEntertainmentCredits> = HashMap()
 
-    override fun updateInfo(movie: NetworkMovie) {
+    fun updateInfo(movie: NetworkMovie) {
         moviesCache[movie.id] = movie
     }
 
-    override fun info(movieId: Int): NetworkMovie? = moviesCache[movieId]
+    fun info(movieId: Int): NetworkMovie? = moviesCache[movieId]
 
-    override fun updateCredits(movieId: Int, credits: NetworkEntertainmentCredits) {
+    fun updateCredits(movieId: Int, credits: NetworkEntertainmentCredits) {
         creditsCache[movieId] = credits
     }
 
-    override fun credits(movieId: Int): NetworkEntertainmentCredits? = creditsCache[movieId]
+    fun credits(movieId: Int): NetworkEntertainmentCredits? = creditsCache[movieId]
 }

--- a/storage/movie/src/main/java/com/kirchhoff/movies/storage/movie/StorageMovieModule.kt
+++ b/storage/movie/src/main/java/com/kirchhoff/movies/storage/movie/StorageMovieModule.kt
@@ -3,5 +3,5 @@ package com.kirchhoff.movies.storage.movie
 import org.koin.dsl.module
 
 val storageMovieModule = module {
-    single<IStorageMovie> { StorageMovie() }
+    single<StorageMovie> { StorageMovie() }
 }

--- a/storage/tvshow/src/main/java/com/kirchhoff/movies/storage/tvshow/StorageTvShow.kt
+++ b/storage/tvshow/src/main/java/com/kirchhoff/movies/storage/tvshow/StorageTvShow.kt
@@ -2,17 +2,12 @@ package com.kirchhoff.movies.storage.tvshow
 
 import com.kirchhoff.movies.networkdata.main.NetworkTv
 
-interface IStorageTvShow {
-    fun updateInfo(tvShow: NetworkTv)
-    fun info(tvShowId: Int): NetworkTv?
-}
-
-internal class StorageTvShow : IStorageTvShow {
+class StorageTvShow {
     private val tvShowCache: MutableMap<Int, NetworkTv> = HashMap()
 
-    override fun updateInfo(tvShow: NetworkTv) {
+    fun updateInfo(tvShow: NetworkTv) {
         tvShowCache[tvShow.id] = tvShow
     }
 
-    override fun info(tvShowId: Int): NetworkTv? = tvShowCache[tvShowId]
+    fun info(tvShowId: Int): NetworkTv? = tvShowCache[tvShowId]
 }

--- a/storage/tvshow/src/main/java/com/kirchhoff/movies/storage/tvshow/StorageTvShowModule.kt
+++ b/storage/tvshow/src/main/java/com/kirchhoff/movies/storage/tvshow/StorageTvShowModule.kt
@@ -3,5 +3,5 @@ package com.kirchhoff.movies.storage.tvshow
 import org.koin.dsl.module
 
 val storageTvShowModule = module {
-    single<IStorageTvShow> { StorageTvShow() }
+    single<StorageTvShow> { StorageTvShow() }
 }


### PR DESCRIPTION
Previously, the project followed a strict interface → implementation pattern in many places:

```text
IReviewRepository -> ReviewRepository
IReviewUseCase -> ReviewUseCase
```

After reviewing the codebase, it became clear that most of these interfaces provided little practical value because they had only a single implementation and no realistic expectation of additional implementations in the future.

As a result, the project contained unnecessary abstraction layers, additional boilerplate, and reduced code navigation.

This PR removes one-to-one interfaces and uses concrete implementations directly.

The only exception is [`IRouter`](https://github.com/Kirchhoff-/Movies/blob/master/core/src/main/java/com/kirchhoff/movies/core/router/IRouter.kt).

[`IRouter`](https://github.com/Kirchhoff-/Movies/blob/master/core/src/main/java/com/kirchhoff/movies/core/router/IRouter.kt) remains because it serves as a boundary between modules. The interface is located in the `core` module, while its implementation [`Router`](https://github.com/Kirchhoff-/Movies/blob/master/app/src/main/java/com/kirchhoff/movies/router/Router.kt) is provided by the `app` module. This allows core components to perform navigation without introducing a dependency on the application layer.

In short, the project is moving away from "interfaces by default" and keeping abstractions only where they provide clear architectural value.

Closes #849 